### PR TITLE
[DEV-265] updated padding on dropdowns

### DIFF
--- a/src/components/SignUp/ActorInfo1.tsx
+++ b/src/components/SignUp/ActorInfo1.tsx
@@ -147,7 +147,7 @@ const ActorInfo1: React.FC<{
               <Form.Group>
                 <Container>
                   <Row>
-                    <Col lg="6">
+                    <PaddedCol lg="6">
                       <CAGLabel>Pronouns</CAGLabel>
                       <Form.Control
                         aria-label="pronouns"
@@ -163,8 +163,8 @@ const ActorInfo1: React.FC<{
                           </option>
                         ))}
                       </Form.Control>
-                    </Col>
-                    <Col lg="6">
+                    </PaddedCol>
+                    <PaddedCol lg="6">
                       <CAGLabel>Other</CAGLabel>
                       <Form.Control
                         aria-label="pronouns"
@@ -173,7 +173,7 @@ const ActorInfo1: React.FC<{
                         name="actorInfo1PronounsOther"
                         onChange={setForm}
                       ></Form.Control>
-                    </Col>
+                    </PaddedCol>
                   </Row>
                 </Container>
               </Form.Group>
@@ -284,5 +284,9 @@ const PrivacyPar = styled.p`
 `;
 
 const InnerEthnicities = styled(Checkbox)``;
+
+const PaddedCol = styled(Col)`
+  padding-left: 0;
+`;
 
 export default ActorInfo1;


### PR DESCRIPTION
[DEV-265](https://artistguide.atlassian.net/browse/DEV-265)

**Description:**

Updated the left padding of the columns to `0` so that they're aligned with the rest of the form

**TESTING**

1. `npm run start`
2. Go to `http://localhost:3000/sign-up`
3. Continue creating a new account and at the `LET'S GET SOME DETAILS` section make sure that the drop-downs align with the rest of the page

**Screenshots (if applicable):**

<img width="942" alt="image" src="https://user-images.githubusercontent.com/9091293/175819817-97023f99-15ec-43f8-a6cd-c9a28b8b4fa3.png">

**PR Checklist:**

- [x] If you haven't made changes to `package.json`, `package-lock.json` is not present in this PR
- [x ] You have tested these changes locally by running the app and letting it build successfully
- [x ] Eslint ran successfully upon commit and `--force` was not used to force this PR

_Make sure you **squash and merge** rather than simply merging all commits at once_.

At least **1** PR approval is required by a Tech Lead to be merged. **2** approvals total are required.