### PR TITLE
[DEV-269][DEV-270] FAQ redirect new tab and updated age range wording

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-datepicker": "^3.6.0",
     "react-dom": "^16.13.1",
     "react-hooks-helper": "^1.6.0",
+    "react-is": "^18.2.0",
     "react-masonry-css": "^1.0.16",
     "react-redux": "^7.2.1",
     "react-router": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "react-datepicker": "^3.6.0",
     "react-dom": "^16.13.1",
     "react-hooks-helper": "^1.6.0",
-    "react-is": "^18.2.0",
     "react-masonry-css": "^1.0.16",
     "react-redux": "^7.2.1",
     "react-router": "^5.2.0",

--- a/src/components/SignUp/ActorInfo1.tsx
+++ b/src/components/SignUp/ActorInfo1.tsx
@@ -215,7 +215,7 @@ const ActorInfo1: React.FC<{
                   of selecting your identity is to help cast roles that call for
                   a certain demographic. Please select as may options as you
                   feel fits your identity. More info on our process{' '}
-                  <Link to="#">here</Link>.
+                  <Link to="/faq" target="_blank">here</Link>.
                 </PrivacyPar>
                 {ethnicityTypes.map(eth => (
                   <React.Fragment key={`parent-frag-chk-${eth.name}`}>

--- a/src/components/SignUp/ActorInfo2.tsx
+++ b/src/components/SignUp/ActorInfo2.tsx
@@ -190,7 +190,7 @@ const ActorInfo2: React.FC<{
               </Form.Group>
               <Form.Group>
                 <CAGLabel>
-                  Age Range <PrivateLabel />
+                  What age range do you play? <PrivateLabel />
                 </CAGLabel>
                 <p>Select up to 3 ranges</p>
                 {ageRanges.map(ageRange => (


### PR DESCRIPTION
[DEV-269](https://artistguide.atlassian.net/browse/DEV-269)
[DEV-270](https://artistguide.atlassian.net/browse/DEV-270)

**Description:**

Changed wording for age range selection

**Screenshots (if applicable):**

Screenshots here

**PR Checklist:**

- [ ] If you haven't made changes to `package.json`, `package-lock.json` is not present in this PR
- [ ] You have tested these changes locally by running the app and letting it build successfully
- [ ] Eslint ran successfully upon commit and `--force` was not used to force this PR

_Make sure you **squash and merge** rather than simply merging all commits at once_.

At least **1** PR approval is required by a Tech Lead to be merged. **2** approvals total are required.