### PR TITLE
[DEV-271] updated left padding on demographis and height

### DIFF
--- a/src/components/SignUp/ActorInfo2.tsx
+++ b/src/components/SignUp/ActorInfo2.tsx
@@ -143,7 +143,7 @@ const ActorInfo2: React.FC<{
                 <CAGLabel>Height</CAGLabel>
                 <Container>
                   <Row>
-                    <Col lg="3">
+                    <PaddedCol lg="3">
                       <Form.Control
                         aria-label="height feet"
                         as="select"
@@ -157,8 +157,8 @@ const ActorInfo2: React.FC<{
                           </option>
                         ))}
                       </Form.Control>
-                    </Col>
-                    <Col lg="3">
+                    </PaddedCol>
+                    <PaddedCol lg="3">
                       <Form.Control
                         aria-label="height inches"
                         as="select"
@@ -175,8 +175,8 @@ const ActorInfo2: React.FC<{
                           </option>
                         ))}
                       </Form.Control>
-                    </Col>
-                    <Col lg="6">
+                    </PaddedCol>
+                    <PaddedCol lg="6">
                       <Checkbox
                         checked={actorInfo2HeightNoAnswer}
                         fieldType="checkbox"
@@ -184,7 +184,7 @@ const ActorInfo2: React.FC<{
                         name="actorInfo2HeightNoAnswer"
                         onChange={setForm}
                       />
-                    </Col>
+                    </PaddedCol>
                   </Row>
                 </Container>
               </Form.Group>
@@ -307,6 +307,10 @@ const CAGLabel = styled(Form.Label)`
 
 const CAGLabelSmaller = styled(CAGLabel as any)`
   font-size: 16px;
+`;
+
+const PaddedCol = styled(Col)`
+  padding-left: 0;
 `;
 
 export default ActorInfo2;

--- a/src/components/SignUp/Demographics.tsx
+++ b/src/components/SignUp/Demographics.tsx
@@ -101,7 +101,7 @@ const Demographics: React.FC<{
               <TitleThree>Union</TitleThree>
               <Container>
                 <Row>
-                  <Col lg="5">
+                  <PaddedCol lg="5">
                     <Form.Control
                       aria-label="union"
                       as="select"
@@ -114,8 +114,8 @@ const Demographics: React.FC<{
                       <option value="Non-Union">Non-Union</option>
                       <option value="Other">Other</option>
                     </Form.Control>
-                  </Col>
-                  <Col lg="5">
+                  </PaddedCol>
+                  <PaddedCol lg="5">
                     <Form.Control
                       aria-label="union"
                       defaultValue=""
@@ -124,12 +124,12 @@ const Demographics: React.FC<{
                       onChange={setForm}
                       placeholder="Other"
                     ></Form.Control>
-                  </Col>
+                  </PaddedCol>
                 </Row>
               </Container>
               <Container>
                 <Row>
-                  <Col lg="8">
+                  <PaddedCol lg="8">
                     <Form.Group>
                       <Form.Control
                         aria-label="agency"
@@ -139,16 +139,16 @@ const Demographics: React.FC<{
                         placeholder="Agency"
                       ></Form.Control>
                     </Form.Group>
-                  </Col>
+                  </PaddedCol>
                 </Row>
               </Container>
               <TitleThree>Website Links</TitleThree>
               <Container>
                 <Row>
-                  <Col lg="10">
+                  <PaddedCol lg="10">
                     {demographicsWebsites.map((websiteRow: any, i: any) => (
                       <div key={`website-row-${websiteRow.id}`}>
-                        <Col lg="12">
+                        <PaddedCol lg="12">
                           <InputField
                             label="URL"
                             name="websiteUrl"
@@ -189,7 +189,7 @@ const Demographics: React.FC<{
                               X
                             </a>
                           )}
-                        </Col>
+                        </PaddedCol>
                       </div>
                     ))}
                     <div>
@@ -197,7 +197,7 @@ const Demographics: React.FC<{
                         + Add Website
                       </a>
                     </div>
-                  </Col>
+                  </PaddedCol>
                 </Row>
               </Container>
             </Col>
@@ -215,6 +215,10 @@ const ImageCol = styled(Col)`
   display: flex;
   max-height: 100%;
   max-width: 100%;
+`;
+
+const PaddedCol = styled(Col)`
+  padding-left: 0;
 `;
 
 export default Demographics;


### PR DESCRIPTION
[DEV-271](https://artistguide.atlassian.net/browse/DEV-271)

**Description:**

Updated the left padding of the columns to `0` so that they're aligned with the rest of the form. Updated on both `height` section as for the ticket and also identified that `Union website` was having the same issue.

**TESTING**

1. `npm run start`
2. Go to `http://localhost:3000/sign-up`
3. Continue creating a new account and at the `LET'S GET SOME DETAILS` section make sure that the drop-downs align with the rest of the page. Continue to the `Union` section and make sure the drop-downs align as well.

**Screenshots (if applicable):**

HEIGHT:
<img width="911" alt="Screen Shot 2022-07-04 at 3 13 46 PM" src="https://user-images.githubusercontent.com/9091293/177212827-b8d92eea-21e1-4867-9cec-e3896a9507e6.png">

UNION:
<img width="913" alt="Screen Shot 2022-07-04 at 3 12 30 PM" src="https://user-images.githubusercontent.com/9091293/177212803-957f8144-4b33-4c3a-8504-444794428565.png">

**PR Checklist:**

- [x] If you haven't made changes to `package.json`, `package-lock.json` is not present in this PR
- [x ] You have tested these changes locally by running the app and letting it build successfully
- [x ] Eslint ran successfully upon commit and `--force` was not used to force this PR

_Make sure you **squash and merge** rather than simply merging all commits at once_.

At least **1** PR approval is required by a Tech Lead to be merged. **2** approvals total are required.