### PR TITLE
Position value in dropdown doesn’t save

### DIFF
--- a/src/components/Profile/Company/Production/Roles/RoleModal.tsx
+++ b/src/components/Profile/Company/Production/Roles/RoleModal.tsx
@@ -140,7 +140,7 @@ const RoleModal: React.FC<{
                   <FormSelect
                     name="role_name"
                     label="Position"
-                    defaultValue={formValues?.offstage_role}
+                    defaultValue={formValues.role_name}
                     onChange={setFormState}
                     hasOptGroups={true}
                     options={transformedOffstageRoleOptions}

--- a/src/components/Profile/Form/Inputs.tsx
+++ b/src/components/Profile/Form/Inputs.tsx
@@ -88,10 +88,7 @@ export const FormSelect: React.FC<{
         name={name}
         placeholder="Choose one..."
         onChange={onChange}
-        defaultValue={defaultValue}
-        style={{
-          color: defaultValue ? colors.secondaryFontColor : colors.lightGrey
-        }}
+        value={defaultValue}
       >
         {hasOptGroups ? (
           <>


### PR DESCRIPTION
After selecting a position and saving, when you go back in, it defaults to 'Directing' in the dropdown value when you go back in to edit, even though the role will say the correct position on the roles page

Changed the value sent (it was sent as undefined)