### PR TITLE
[DEV-496] Public role browse follow-up + Individual profile crash guard

### DIFF
--- a/src/components/Profile/Company/Production/AddProduction.tsx
+++ b/src/components/Profile/Company/Production/AddProduction.tsx
@@ -160,10 +160,15 @@ const CompanyAddShow: React.FC<
   const handleSubmit = async () => {
     const productionId = uuidv4();
     try {
+      const resolvedTheaterName: string =
+        (profileData as any)?.theatre_name ||
+        (accountData as any)?.theater_name ||
+        '';
       const payload = sanitizeDataForFirestore({
         ...formValues,
         production_id: productionId,
-        account_id: formValues.account_id || ownerAccountId
+        account_id: formValues.account_id || ownerAccountId,
+        theater_name: resolvedTheaterName
       });
 
       await setDoc(doc(db, 'productions', productionId), payload);

--- a/src/components/Profile/Company/Production/AddProduction.tsx
+++ b/src/components/Profile/Company/Production/AddProduction.tsx
@@ -150,8 +150,6 @@ const CompanyAddShow: React.FC<
     setShowOtherType(formValues.type === 'Other');
   }, [formValues.type]);
 
-  console.log(profileData);
-
   const setProfilePicture = (url: string) => {
     const target = { name: 'production_image_url', value: url };
     setFormValues({ target });
@@ -173,7 +171,6 @@ const CompanyAddShow: React.FC<
 
       await setDoc(doc(db, 'productions', productionId), payload);
       toggleEdit();
-      console.log(productionId);
     } catch (error) {
       console.error('Error creating production:', error);
     }

--- a/src/components/Profile/Company/types.ts
+++ b/src/components/Profile/Company/types.ts
@@ -44,6 +44,7 @@ export type Production = {
   account_id: string;
   production_id: string;
   production_name: string;
+  theater_name?: string;
   production_image_url?: string;
   type?: ProductionType;
   type_other?: string;

--- a/src/components/Profile/Individual/EditPersonalDetails.tsx
+++ b/src/components/Profile/Individual/EditPersonalDetails.tsx
@@ -226,7 +226,7 @@ const EditPersonalDetails = ({
               <React.Fragment key={`parent-frag-chk-${eth.name}`}>
                 {eth.values.map((ethV) => (
                   <Checkbox
-                    checked={editProfile?.ethnicities.includes(ethV)}
+                    checked={(editProfile?.ethnicities || []).includes(ethV)}
                     fieldType="checkbox"
                     key={`${eth.name}-child-chk-${ethV}`}
                     label={ethV}
@@ -242,7 +242,7 @@ const EditPersonalDetails = ({
           return (
             <React.Fragment key={`parent-frag-chk-${eth.name}`}>
               <Checkbox
-                checked={editProfile?.ethnicities.includes(eth.name)}
+                checked={(editProfile?.ethnicities || []).includes(eth.name)}
                 fieldType="checkbox"
                 key={`first-level-chk-${eth.name}`}
                 label={eth.name}
@@ -255,7 +255,7 @@ const EditPersonalDetails = ({
                 <Checkbox style={{ paddingLeft: '1.25rem' }}>
                   {eth.values.map((ethV) => (
                     <Checkbox
-                      checked={editProfile?.ethnicities.includes(ethV)}
+                      checked={(editProfile?.ethnicities || []).includes(ethV)}
                       fieldType="checkbox"
                       key={`${eth.name}-child-chk-${ethV}`}
                       label={ethV}

--- a/src/components/PublicShows/PublicShowCard.tsx
+++ b/src/components/PublicShows/PublicShowCard.tsx
@@ -10,6 +10,7 @@ import {
   getTheaterByAccountId
 } from '../Profile/Company/api';
 import { useFirebaseContext } from '../../context/FirebaseContext';
+import { useUserContext } from '../../context/UserContext';
 
 interface PublicShowCardProps {
   show: Production;
@@ -19,21 +20,36 @@ const PublicShowCard: React.FC<
   React.PropsWithChildren<PublicShowCardProps>
 > = ({ show }) => {
   const { firebaseFirestore } = useFirebaseContext();
-  const [theaterName, setTheaterName] = useState<string>('');
+  const { currentUser } = useUserContext();
+  const [theaterName, setTheaterName] = useState<string>(
+    show.theater_name || ''
+  );
 
   useEffect(() => {
-    // Flag to track if the component is mounted
+    // If the production already has a denormalized theater_name, use it directly.
+    if (show.theater_name) {
+      setTheaterName(show.theater_name);
+      return;
+    }
+
+    // For anonymous users, never call the auth-gated accounts query.
+    if (!currentUser) {
+      setTheaterName('');
+      return;
+    }
+
+    // Authenticated users: best-effort fallback for un-backfilled legacy productions.
+    if (!show.account_id) {
+      setTheaterName('');
+      return;
+    }
+
     let isMounted = true;
 
     // production.account_id is the company's auth uid (see AddProduction.tsx),
     // not a Firestore doc id. Look up the account by uid, then prefer the
     // profile's theatre_name, falling back to the account's theater_name.
     const fetchTheaterName = async () => {
-      if (!show || !show.account_id) {
-        if (isMounted) setTheaterName('Unknown Theater');
-        return;
-      }
-
       try {
         const account = await getTheaterAccountByUid(
           firebaseFirestore,
@@ -43,7 +59,7 @@ const PublicShowCard: React.FC<
         if (!isMounted) return;
 
         if (!account) {
-          setTheaterName('Unknown Theater');
+          setTheaterName('');
           return;
         }
 
@@ -58,22 +74,18 @@ const PublicShowCard: React.FC<
           (profile && profile.theatre_name) ||
           (account as any).theater_name ||
           '';
-        setTheaterName(resolvedName || 'Unknown Theater');
-      } catch (error) {
-        if (isMounted) {
-          console.error('Error fetching theater name:', error);
-          setTheaterName('Unknown Theater');
-        }
+        setTheaterName(resolvedName);
+      } catch {
+        // Silently ignore — theater name is non-critical display data.
       }
     };
 
     fetchTheaterName();
 
-    // Cleanup function to prevent state updates on unmounted component
     return () => {
       isMounted = false;
     };
-  }, [show?.account_id, firebaseFirestore]);
+  }, [show.theater_name, show.account_id, currentUser, firebaseFirestore]);
 
   return (
     <ShowCard>
@@ -85,9 +97,11 @@ const PublicShowCard: React.FC<
           <div className="d-flex flex-column" style={{ height: '100%' }}>
             <div className="flex-grow-1">
               <ShowName>{show?.production_name}</ShowName>
-              <TheaterNameLink to={`/profile/view/${show?.account_id}`}>
-                {theaterName}
-              </TheaterNameLink>
+              {theaterName ? (
+                <TheaterNameLink to={`/profile/view/${show?.account_id}`}>
+                  {theaterName}
+                </TheaterNameLink>
+              ) : null}
               <ShowStatus>{show?.status}</ShowStatus>
               <ShowDescription>{show?.description}</ShowDescription>
             </div>

--- a/src/components/PublicShows/api.ts
+++ b/src/components/PublicShows/api.ts
@@ -64,7 +64,11 @@ export const fetchPublicOpenRoles = async (
     // are treated as open by convention (matches PublicShowDetail behaviour
     // where the role still appears for unauth viewers).
     const openRoles = roles.filter(
-      (r) => r && (r.role_status === undefined || r.role_status === 'Open')
+      (r) =>
+        r &&
+        typeof r === 'object' &&
+        !Array.isArray(r) &&
+        (r.role_status === undefined || r.role_status === 'Open')
     );
 
     if (openRoles.length === 0) {

--- a/src/routes/ManageProduction.tsx
+++ b/src/routes/ManageProduction.tsx
@@ -27,7 +27,8 @@ const ManageProduction = () => {
   const navigate = useNavigate();
   const { firebaseFirestore: db } = useFirebaseContext();
   const {
-    account: { data: accountData }
+    account: { data: accountData },
+    profile: { data: profileData }
   } = useUserContext();
   const ownerAccountId = accountData?.uid || accountData?.account_id || '';
   const [showConfirm, setShowConfirm] = useState(false);
@@ -111,10 +112,16 @@ const ManageProduction = () => {
 
   const handleUpdateDocument = async (values: Production) => {
     const docRef = doc(db, 'productions', productionId);
+    const resolvedTheaterName: string =
+      values.theater_name ||
+      (accountData as any)?.theater_name ||
+      (profileData as any)?.theatre_name ||
+      '';
     const payload = sanitizeDataForFirestore({
       ...values,
       production_id: values.production_id || productionId,
-      account_id: values.account_id || ownerAccountId
+      account_id: values.account_id || ownerAccountId,
+      theater_name: resolvedTheaterName
     });
 
     await updateDoc(docRef, payload);

--- a/src/routes/ManageProduction.tsx
+++ b/src/routes/ManageProduction.tsx
@@ -112,11 +112,19 @@ const ManageProduction = () => {
 
   const handleUpdateDocument = async (values: Production) => {
     const docRef = doc(db, 'productions', productionId);
+    // Preserve existing theater_name (incl. empty string) on update —
+    // only auto-resolve when the field is genuinely missing AND the saver
+    // owns this production. Prevents an admin/collaborator editing
+    // another company's production from overwriting it with their own
+    // theatre name. Mirrors AddProduction's profile-first priority.
+    const isOwner = !!ownerAccountId && values.account_id === ownerAccountId;
     const resolvedTheaterName: string =
-      values.theater_name ||
-      (accountData as any)?.theater_name ||
-      (profileData as any)?.theatre_name ||
-      '';
+      values.theater_name ??
+      (isOwner
+        ? (profileData as any)?.theatre_name ||
+          (accountData as any)?.theater_name ||
+          ''
+        : '');
     const payload = sanitizeDataForFirestore({
       ...values,
       production_id: values.production_id || productionId,

--- a/src/routes/PublicShowDetail.tsx
+++ b/src/routes/PublicShowDetail.tsx
@@ -105,6 +105,9 @@ const PublicShowDetail = () => {
 
           // Set the show data
           setShow(productionData);
+        } else if (isMounted) {
+          // Production no longer exists — clear any stale state from a prior render.
+          setShow(null);
         }
 
         if (isMounted) {
@@ -215,9 +218,11 @@ const PublicShowDetail = () => {
             ← Back to shows (page {savedPaginationState.currentPage || 1})
           </BackLink>
           <Title>{show.production_name}</Title>
-          <TheaterNameLink to={`/profile/view/${show.account_id}`}>
-            {theaterName}
-          </TheaterNameLink>
+          {theaterName ? (
+            <TheaterNameLink to={`/profile/view/${show.account_id}`}>
+              {theaterName}
+            </TheaterNameLink>
+          ) : null}
         </Col>
       </Row>
 

--- a/src/routes/PublicShowDetail.tsx
+++ b/src/routes/PublicShowDetail.tsx
@@ -129,16 +129,27 @@ const PublicShowDetail = () => {
         setTheaterName(productionData.theater_name);
       } else if (currentUser && productionData.account_id) {
         try {
-          const theater = await getTheaterByAccountUid(
+          const theaterAccount = await getTheaterAccountByUid(
             firebaseFirestore,
             productionData.account_id
           );
 
           if (!isMounted) return;
 
-          setTheaterName(
-            theater && theater.theatre_name ? theater.theatre_name : ''
-          );
+          if (theaterAccount) {
+            const theaterProfile = await getTheaterByAccountId(
+              firebaseFirestore,
+              theaterAccount.id
+            );
+
+            if (!isMounted) return;
+
+            const resolvedName =
+              (theaterProfile && theaterProfile.theatre_name) ||
+              (theaterAccount as any).theater_name ||
+              '';
+            setTheaterName(resolvedName);
+          }
         } catch {
           // Silently ignore — theater name is non-critical display data.
         }

--- a/src/routes/PublicShowDetail.tsx
+++ b/src/routes/PublicShowDetail.tsx
@@ -41,6 +41,9 @@ const PublicShowDetail = () => {
         return;
       }
 
+      // Outer try/catch wraps ONLY the production fetch.
+      // If this fails, show is set to null and loading stops.
+      let productionData: Production | null = null;
       try {
         const productionRef = doc(
           firebaseFirestore,
@@ -56,12 +59,13 @@ const PublicShowDetail = () => {
           const rawData = productionDoc.data();
 
           // Create a valid Production object with required fields
-          const productionData: Production = {
+          productionData = {
             // Required fields with fallbacks
             production_id: rawData.production_id || productionDoc.id,
             production_name: rawData.production_name || 'Untitled Production',
             account_id: rawData.account_id || '',
             location: rawData.location || '',
+            theater_name: rawData.theater_name || '',
 
             // Optional fields
             production_image_url: rawData.production_image_url,
@@ -101,34 +105,6 @@ const PublicShowDetail = () => {
 
           // Set the show data
           setShow(productionData);
-
-          // Fetch theater name. account_id is the auth uid; pull both account
-          // and profile so we can fall back from theatre_name to theater_name.
-          if (productionData.account_id) {
-            const theaterAccount = await getTheaterAccountByUid(
-              firebaseFirestore,
-              productionData.account_id
-            );
-
-            if (!isMounted) return;
-
-            if (theaterAccount) {
-              const theaterProfile = await getTheaterByAccountId(
-                firebaseFirestore,
-                theaterAccount.id
-              );
-
-              if (!isMounted) return;
-
-              const resolvedName =
-                (theaterProfile && theaterProfile.theatre_name) ||
-                (theaterAccount as any).theater_name ||
-                '';
-              setTheaterName(resolvedName || 'Unknown Theater');
-            } else {
-              setTheaterName('Unknown Theater');
-            }
-          }
         }
 
         if (isMounted) {
@@ -140,6 +116,32 @@ const PublicShowDetail = () => {
           setShow(null);
           setLoading(false);
         }
+        return;
+      }
+
+      if (!productionData || !isMounted) return;
+
+      // Theater-name lookup: best-effort, in its own catch so it never
+      // wipes out a successfully-fetched production.
+      // Use the denormalized field first; only call the auth-gated query
+      // when the user is authenticated and the field is missing (legacy data).
+      if (productionData.theater_name) {
+        setTheaterName(productionData.theater_name);
+      } else if (currentUser && productionData.account_id) {
+        try {
+          const theater = await getTheaterByAccountUid(
+            firebaseFirestore,
+            productionData.account_id
+          );
+
+          if (!isMounted) return;
+
+          setTheaterName(
+            theater && theater.theatre_name ? theater.theatre_name : ''
+          );
+        } catch {
+          // Silently ignore — theater name is non-critical display data.
+        }
       }
     };
 
@@ -149,7 +151,7 @@ const PublicShowDetail = () => {
     return () => {
       isMounted = false;
     };
-  }, [productionId, firebaseFirestore]);
+  }, [productionId, firebaseFirestore, currentUser]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary

Follow-up to PR #315 (DEV-496 Marketing MVP). UAT against staging surfaced four anonymous-flow failures and one Individual profile editor crash. This PR addresses all of them, then incorporates code-review feedback from two parallel reviewer agents.

## Changes

### DEV-496 — Public role browse fixes
- **Denormalize `theater_name`** onto production docs at save time (`AddProduction.tsx`, `ManageProduction.tsx`, `Production` type). Public flows now read `show.theater_name` directly and never call the auth-gated `accounts` query for anonymous users — this kills the 18× `FirebaseError: Missing or insufficient permissions` storm and the 3–15s `ERR_CONNECTION_CLOSED` teardown that anon users were seeing on `/shows`.
- **Split the broad catch** in `PublicShowDetail.tsx` so an auth-gated theater-name lookup failure no longer wipes out a successfully-fetched production (which was producing "Show Not Found" for anon visitors). Outer try wraps only the production fetch; theater-name has its own inner try.
- **Reject non-object role entries** in `fetchPublicOpenRoles` (`PublicShows/api.ts`). Defensive guard against staging data where `roles` arrays contain primitives — previously caused cards to render heading "1".
- **Fix typo** in post-catch lookup (`getTheaterByAccountUid` → two-step `getTheaterAccountByUid` + `getTheaterByAccountId`). The non-existent function would have crashed for any authed user hitting the legacy fallback path.

### Individual profile editor — undefined.includes crash
- Default `editProfile.ethnicities` to `[]` at three `.includes(...)` call sites in `EditPersonalDetails.tsx`. Prevents `TypeError: Cannot read properties of undefined (reading 'includes')` when a profile lands in an incomplete state (e.g. LGL CORS abort during signup left arrays unset).

### Code-review fixes (cb6297a)
- `PublicShowDetail.tsx` `<TheaterNameLink>` is now wrapped in `{theaterName ? ... : null}` (matches PublicShowCard pattern). Was rendering an invisible empty `<a>` to `/profile/view/` for anon users on un-backfilled productions.
- `PublicShowDetail.tsx` clears `show` state when the production doc no longer exists, so deleted productions stop rendering stale data after the auth-driven effect re-runs.
- `ManageProduction.tsx` only auto-resolves `theater_name` when the saver owns the production AND the field is genuinely missing (nullish-coalesce, not falsy fallback). Stops admins/collaborators editing another company's production from overwriting it with their own theatre name. Fallback priority now matches AddProduction (profile before account).
- `AddProduction.tsx` drops two stray `console.log` statements left from development.

## Backfill

Existing productions saved before this PR will not have `theater_name` on their Firestore documents. Anonymous browsers will see no theatre link on those cards (intentional — better than "Unknown Theater"). Authenticated users get the legacy two-step fallback. Any time a company opens and saves a production via Manage Production after this lands, the field is backfilled automatically. A one-time backfill script can be added separately if the team wants legacy productions to show theatre names to anonymous users immediately.

## Test plan

- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Husky lint-staged passes on each commit
- [x] DEV-491 visual regression harness re-run (post-build): 11/11 public routes pixel-identical or within antialias tolerance
- [x] Two reviewer agents (correctness + adversarial) — all HIGH issues fixed; deferred follow-ups (re-fetch effect split, primitive-role test) noted in commit thread
- [ ] Re-run DEV-496 UAT on staging once this branch deploys: anon `/shows` listing should show real production/role names with no permission errors, theatre name link present on backfilled productions and absent on legacy ones, anon `/shows/<id>` should render without redirect or "Show Not Found"
- [ ] Spot-check Individual profile editor on an account with incomplete data — Edit Personal Details should no longer crash

## Deferred follow-ups

- Split `PublicShowDetail` effect to avoid redundant production re-fetch on auth resolve (perf, MEDIUM)
- Add regression test in `publicShowsApi.test.ts` for the primitive-role guard (LOW)
- One-time Firestore backfill script for `theater_name` on legacy productions (optional)