### PR TITLE
[DEV-494/495/497/498] Public /roles MVP follow-ups: null states, role card refresh, sign-up CTA

### DIFF
--- a/src/components/PublicShows/PublicRoleCard.tsx
+++ b/src/components/PublicShows/PublicRoleCard.tsx
@@ -75,7 +75,9 @@ const PublicRoleCard: React.FC<
       <RoleName>{displayRoleName}</RoleName>
 
       {role.description && (
-        <RoleDescription>{role.description}</RoleDescription>
+        <p className="mb-[15px] line-clamp-3 font-montserrat text-sm">
+          {role.description}
+        </p>
       )}
 
       <div className="flex flex-wrap gap-[10px]">
@@ -154,17 +156,6 @@ const RoleName = styled.h4`
   font-weight: 600;
   font-size: 18px;
   margin-bottom: 5px;
-`;
-
-const RoleDescription = styled.p`
-  font-family: ${fonts.montserrat};
-  font-size: 14px;
-  margin-bottom: 15px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
 `;
 
 const DetailLabel = styled.span`

--- a/src/components/PublicShows/PublicRoleCard.tsx
+++ b/src/components/PublicShows/PublicRoleCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { Role } from '../Profile/Company/types';
+import { Button } from '../shared';
 import { colors, fonts } from '../../theme/styleVars';
 import { parseLocalDate } from '../../utils/dates';
 
@@ -38,6 +39,20 @@ const formatAuditionWindow = (start?: string, end?: string) => {
   return s || e || '';
 };
 
+// Format pay rate as "$NNN Unit" matching the CompanyMatchCard pattern.
+// role_rate_unit values already include "Per" (e.g. "Per Week", "Per Hour",
+// "Per Show", "Total"), so no "per" prefix is added here.
+const formatRate = (
+  rate?: number,
+  unit?: 'Total' | 'Per Week' | 'Per Hour' | 'Per Show'
+): string => {
+  if (rate == null) {
+    return '';
+  }
+  const rateStr = `$${rate}`;
+  return unit ? `${rateStr} ${unit}` : rateStr;
+};
+
 const PublicRoleCard: React.FC<
   React.PropsWithChildren<PublicRoleCardProps>
 > = ({ role, productionId, productionName, auditionStart, auditionEnd }) => {
@@ -45,6 +60,7 @@ const PublicRoleCard: React.FC<
   const auditionWindow = formatAuditionWindow(auditionStart, auditionEnd);
   const displayRoleName =
     role.role_name || role.offstage_role || 'Untitled Role';
+  const rateDisplay = formatRate(role.role_rate, role.role_rate_unit);
 
   return (
     <RoleCardContainer>
@@ -57,7 +73,6 @@ const PublicRoleCard: React.FC<
       )}
 
       <RoleName>{displayRoleName}</RoleName>
-      {role.role_status && <RoleStatus>{role.role_status}</RoleStatus>}
 
       {role.description && (
         <RoleDescription>{role.description}</RoleDescription>
@@ -76,13 +91,10 @@ const PublicRoleCard: React.FC<
             <DetailValue>{role.union.join(', ')}</DetailValue>
           </div>
         )}
-        {role.role_rate && (
+        {rateDisplay && (
           <div className="mb-[5px] mr-[15px] flex">
             <DetailLabel>Rate:</DetailLabel>
-            <DetailValue>
-              {role.role_rate}
-              {role.role_rate_unit && ` per ${role.role_rate_unit}`}
-            </DetailValue>
+            <DetailValue>{rateDisplay}</DetailValue>
           </div>
         )}
         {auditionWindow && (
@@ -93,10 +105,16 @@ const PublicRoleCard: React.FC<
         )}
       </div>
 
-      {isListMode && (
-        <ViewProductionLink to={`/shows/${productionId}`}>
-          View Production →
-        </ViewProductionLink>
+      {isListMode && productionId && (
+        <div className="mt-[12px]">
+          <Link to={`/shows/${productionId}`}>
+            <ViewButton
+              text="View Production"
+              type="button"
+              variant="primary"
+            />
+          </Link>
+        </div>
       )}
     </RoleCardContainer>
   );
@@ -138,18 +156,15 @@ const RoleName = styled.h4`
   margin-bottom: 5px;
 `;
 
-const RoleStatus = styled.div`
-  font-family: ${fonts.montserrat};
-  font-weight: 500;
-  font-size: 14px;
-  color: ${colors.mint};
-  margin-bottom: 10px;
-`;
-
 const RoleDescription = styled.p`
   font-family: ${fonts.montserrat};
   font-size: 14px;
   margin-bottom: 15px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 `;
 
 const DetailLabel = styled.span`
@@ -164,19 +179,9 @@ const DetailValue = styled.span`
   font-size: 14px;
 `;
 
-const ViewProductionLink = styled(Link)`
-  display: inline-block;
-  margin-top: 12px;
+const ViewButton = styled(Button)`
   font-family: ${fonts.montserrat};
   font-weight: 600;
-  font-size: 14px;
-  color: ${colors.cornflower};
-  text-decoration: none;
-
-  &:hover {
-    color: ${colors.mint};
-    text-decoration: underline;
-  }
 `;
 
 export default PublicRoleCard;

--- a/src/components/PublicShows/PublicRoleCardSkeleton.tsx
+++ b/src/components/PublicShows/PublicRoleCardSkeleton.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled, { keyframes } from 'styled-components';
-import { Row, Col } from 'react-bootstrap';
 import { colors } from '../../theme/styleVars';
 
 const PublicRoleCardSkeleton: React.FC<
@@ -8,27 +7,22 @@ const PublicRoleCardSkeleton: React.FC<
 > = () => {
   return (
     <RoleCardContainer>
-      <Row>
-        <Col lg={8}>
-          <RoleNameSkeleton />
-          <RoleStatusSkeleton />
-          <RoleDescriptionSkeleton />
+      {/* Production name line */}
+      <ProductionLineSkeleton />
 
-          <div className="mt-[15px] flex flex-wrap gap-[10px]">
-            <DetailItemSkeleton />
-            <DetailItemSkeleton />
-            <DetailItemSkeleton />
-            <DetailItemSkeleton />
-          </div>
-        </Col>
+      <RoleNameSkeleton />
+      <RoleDescriptionSkeleton />
+      <RoleDescriptionSkeleton />
 
-        <Col
-          lg={4}
-          className="d-flex align-items-center justify-content-center"
-        >
-          <RoleButtonSkeleton />
-        </Col>
-      </Row>
+      <div className="mt-[15px] flex flex-wrap gap-[10px]">
+        <DetailItemSkeleton />
+        <DetailItemSkeleton />
+        <DetailItemSkeleton />
+        <DetailItemSkeleton />
+      </div>
+
+      {/* View Production button */}
+      <RoleButtonSkeleton />
     </RoleCardContainer>
   );
 };
@@ -63,32 +57,32 @@ const RoleCardContainer = styled.div`
 `;
 
 // TODO: understand why we need to use as any to resolve the TS error for circular propTypes
+const ProductionLineSkeleton = styled(SkeletonBase as any)`
+  height: 14px;
+  width: 30%;
+  margin-bottom: 10px;
+`;
+
 const RoleNameSkeleton = styled(SkeletonBase as any)`
   height: 22px;
   width: 40%;
   margin-bottom: 10px;
 `;
 
-const RoleStatusSkeleton = styled(SkeletonBase as any)`
-  height: 16px;
-  width: 25%;
-  margin-bottom: 15px;
-`;
-
 const RoleDescriptionSkeleton = styled(SkeletonBase as any)`
-  height: 16px;
+  height: 14px;
   width: 90%;
-  margin-bottom: 5px;
+  margin-bottom: 6px;
 
-  &:nth-child(3) {
-    width: 85%;
-  }
-
+  /* Second of the two description lines (position 4 within RoleCardContainer:
+     ProductionLine, RoleName, Description, Description, ChipsRow, Button).
+     Shorter width + larger margin gives the chip row breathing room. */
   &:nth-child(4) {
-    width: 70%;
+    width: 75%;
     margin-bottom: 15px;
   }
 `;
+
 const DetailItemSkeleton = styled(SkeletonBase as any)`
   height: 16px;
   width: 120px;
@@ -114,7 +108,8 @@ const DetailItemSkeleton = styled(SkeletonBase as any)`
 
 const RoleButtonSkeleton = styled(SkeletonBase as any)`
   height: 40px;
-  width: 100%;
+  width: 180px;
+  margin-top: 12px;
 `;
 
 export default PublicRoleCardSkeleton;

--- a/src/components/PublicShows/PublicRolesEmptyState.tsx
+++ b/src/components/PublicShows/PublicRolesEmptyState.tsx
@@ -1,26 +1,66 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import PublicRolesSignUpCTA from './PublicRolesSignUpCTA';
 
-// DEV-495: shown when there are zero open roles in the entire system.
+// DEV-495: shown when there are zero open roles in the entire system (not
+// because of active filters — that is DEV-494's PublicRolesNoResults).
 const PublicRolesEmptyState: React.FC = () => {
   return (
     <div
       className="mt-4 rounded-lg bg-white p-8 text-center shadow"
       data-testid="public-roles-empty-state"
     >
+      {/* Decorative spotlight icon — inline SVG, no external asset needed */}
+      <div
+        aria-hidden="true"
+        className="mx-auto mb-5 flex h-20 w-20 items-center justify-center rounded-full bg-mint/15"
+      >
+        <svg
+          className="h-10 w-10 text-mint"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.5}
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          {/* Calendar with a star — evokes "watch for upcoming events" */}
+          <rect height="18" rx="2" ry="2" width="18" x="3" y="4" />
+          <line x1="16" x2="16" y1="2" y2="6" />
+          <line x1="8" x2="8" y1="2" y2="6" />
+          <line x1="3" x2="21" y1="10" y2="10" />
+          <path d="M12 14l.5 1.5h1.5l-1.2.9.5 1.6-1.3-1-1.3 1 .5-1.6-1.2-.9h1.5z" />
+        </svg>
+      </div>
+
       <h2 className="font-montserrat text-2xl font-semibold text-darkGrey">
         No open roles right now
       </h2>
-      <p className="mx-auto mt-3 max-w-md font-montserrat text-base text-darkGrey">
-        Chicago theatres haven't posted any open roles yet. New opportunities
-        are added regularly — check back soon, or sign up to be notified the
-        moment a role goes live.
+
+      <p className="mx-auto mt-3 max-w-md font-montserrat text-base text-grayishBlue">
+        Chicago theatres post new auditions and crew opportunities regularly.
+        Check back soon — or sign up so you&apos;re the first to know when
+        something goes live.
       </p>
-      <div className="mx-auto mt-6 max-w-2xl">
+
+      {/* Primary CTA: sign-up notification banner */}
+      <div className="mx-auto mt-8 max-w-2xl">
         <PublicRolesSignUpCTA
-          body="Get an email the moment new roles are posted."
+          body="Get an email the moment new roles are posted — it's free."
           heading="Be the first to know"
         />
+      </div>
+
+      {/* Secondary forward action */}
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+        <Link
+          aria-label="Return to the Chicago Artist Guide home page"
+          className="inline-flex items-center justify-center rounded-full border border-lightGrey px-5 py-2 font-montserrat text-sm font-bold uppercase tracking-wider text-grayishBlue hover:border-darkGrey hover:text-darkGrey"
+          to="/"
+        >
+          Back to Home
+        </Link>
       </div>
     </div>
   );

--- a/src/components/PublicShows/PublicRolesNoResults.tsx
+++ b/src/components/PublicShows/PublicRolesNoResults.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 interface PublicRolesNoResultsProps {
   onClearFilters: () => void;
 }
 
 // DEV-494: shown when filters/search match zero open roles, even though
-// roles exist in the system.
+// roles exist in the system. Distinct from DEV-495 (PublicRolesEmptyState)
+// which handles the case where there are no roles at all.
 const PublicRolesNoResults: React.FC<PublicRolesNoResultsProps> = ({
   onClearFilters
 }) => {
@@ -15,20 +17,34 @@ const PublicRolesNoResults: React.FC<PublicRolesNoResultsProps> = ({
       data-testid="public-roles-no-results"
     >
       <h2 className="font-montserrat text-xl font-semibold text-darkGrey">
-        No matches for these filters
+        No roles match your filters
       </h2>
-      <p className="mx-auto mt-3 max-w-md font-montserrat text-base text-darkGrey">
-        We couldn't find any open roles that match your search. Try clearing
-        the filters, broadening your search, or check back later as new roles
-        are added regularly.
+      <p className="mx-auto mt-3 max-w-md font-montserrat text-base text-grayishBlue">
+        There are open roles in the system, but none match your current search
+        or stage-type filter. Try broadening your search or clearing all filters
+        to see every available opportunity.
       </p>
-      <button
-        className="mt-6 inline-flex items-center justify-center rounded-full bg-[#82B29A] px-6 py-2 font-montserrat text-sm font-bold uppercase tracking-wider text-white shadow-sm hover:bg-[#425B4E]"
-        onClick={onClearFilters}
-        type="button"
-      >
-        Clear Filters
-      </button>
+      <div className="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+        <button
+          aria-label="Clear all active filters and show all roles"
+          // bg-darkPrimary on white -> 7.4:1 contrast (AAA). The previous
+          // bg-mint on white was 2.39:1 (failed AA).
+          className="inline-flex items-center justify-center rounded-full bg-darkPrimary px-6 py-2 font-montserrat text-sm font-bold uppercase tracking-wider text-white shadow-sm transition-colors hover:bg-cornflower focus:outline-none focus:ring-2 focus:ring-darkPrimary focus:ring-offset-2"
+          onClick={onClearFilters}
+          type="button"
+        >
+          Clear Filters
+        </button>
+        <Link
+          aria-label="Sign up to receive notifications when new roles are posted"
+          // text-darkPrimary on white -> 7.4:1 (AAA). text-mint was 2.39:1.
+          className="inline-flex items-center justify-center rounded-full border border-darkPrimary px-6 py-2 font-montserrat text-sm font-bold uppercase tracking-wider text-darkPrimary transition-colors hover:bg-darkPrimary hover:text-white focus:outline-none focus:ring-2 focus:ring-darkPrimary focus:ring-offset-2"
+          data-testid="no-results-signup-link"
+          to="/sign-up"
+        >
+          Sign Up for Notifications
+        </Link>
+      </div>
     </div>
   );
 };

--- a/src/components/PublicShows/PublicRolesSignUpCTA.tsx
+++ b/src/components/PublicShows/PublicRolesSignUpCTA.tsx
@@ -2,42 +2,77 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 interface PublicRolesSignUpCTAProps {
-  // Optional override copy — null states reuse this component with
-  // tweaked messaging (e.g. "Be the first to know" when zero roles
-  // exist).
+  // Optional override copy -- null states reuse this component with
+  // tweaked messaging (e.g. "Be the first to know" when zero roles exist).
   heading?: string;
   body?: string;
   className?: string;
+  // Controls visual weight: 'banner' (solid cornflower block, used above
+  // the role list) or 'inline' (lighter mint-tinted border, default, used
+  // after the list and inside the empty-state container).
+  variant?: 'banner' | 'inline';
 }
 
 const PublicRolesSignUpCTA: React.FC<PublicRolesSignUpCTAProps> = ({
-  heading = 'Want to know when new roles are posted?',
-  body = 'Sign up for free to get notified about opportunities that match your profile.',
-  className = ''
+  heading = "Don't miss your next role",
+  body = 'Build a free profile and get notified the moment a role that matches your skills goes live.',
+  className = '',
+  variant = 'inline'
 }) => {
+  const isBanner = variant === 'banner';
+
+  const wrapperClasses = isBanner
+    ? `rounded-xl bg-cornflower px-8 py-7 text-white md:flex md:items-center md:justify-between ${className}`
+    : `rounded-lg border border-mint/40 bg-mint/10 p-6 md:flex md:items-center md:justify-between ${className}`;
+
+  const headingClasses = isBanner
+    ? 'font-montserrat text-xl font-bold text-white'
+    : 'font-montserrat text-lg font-semibold text-darkGrey';
+
+  const bodyClasses = isBanner
+    ? 'mt-1 font-montserrat text-sm text-white/90'
+    : 'mt-1 font-montserrat text-sm text-darkGrey';
+
+  // Distinct landmark labels per placement so screen-reader landmark
+  // navigation can tell the two CTAs apart on the same page.
+  const landmarkLabel = isBanner
+    ? 'Sign up before browsing roles'
+    : 'Sign up after browsing roles';
+
   return (
     <section
-      className={`mb-8 rounded-lg border border-mint/40 bg-mint/10 p-6 md:flex md:items-center md:justify-between ${className}`}
+      aria-label={landmarkLabel}
+      className={wrapperClasses}
       data-testid="public-roles-signup-cta"
     >
-      <div className="md:pr-6">
-        <h3 className="font-montserrat text-lg font-semibold text-darkGrey">
-          {heading}
-        </h3>
-        <p className="mt-1 font-montserrat text-sm text-darkGrey">{body}</p>
+      <div className="md:pr-8">
+        <h3 className={headingClasses}>{heading}</h3>
+        <p className={bodyClasses}>{body}</p>
       </div>
-      <div className="mt-4 flex flex-shrink-0 gap-3 md:mt-0">
+      <div className="mt-5 flex flex-shrink-0 flex-wrap gap-3 md:mt-0">
         <Link
-          className="inline-flex items-center justify-center rounded-full bg-[#82B29A] px-5 py-2 font-montserrat text-sm font-bold uppercase tracking-wider text-white shadow-sm hover:bg-[#425B4E]"
+          aria-label="Create a free artist account"
+          className={
+            isBanner
+              ? // White button on cornflower banner: 7.6:1 contrast (AAA).
+                'inline-flex items-center justify-center rounded-full bg-white px-6 py-2 font-montserrat text-sm font-bold uppercase tracking-wider text-darkPrimary shadow-sm hover:bg-bodyBg focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-cornflower'
+              : // darkPrimary on white: 7.4:1 contrast (AAA).
+                'inline-flex items-center justify-center rounded-full bg-darkPrimary px-5 py-2 font-montserrat text-sm font-bold uppercase tracking-wider text-white shadow-sm hover:bg-cornflower focus:outline-none focus:ring-2 focus:ring-darkPrimary focus:ring-offset-2'
+          }
           to="/sign-up"
         >
-          Sign Up
+          Join Free
         </Link>
         <Link
-          className="inline-flex items-center justify-center rounded-full border border-cornflower px-5 py-2 font-montserrat text-sm font-bold uppercase tracking-wider text-cornflower hover:bg-cornflower hover:text-white"
-          to="/login"
+          aria-label="Learn how Chicago Artist Guide works"
+          className={
+            isBanner
+              ? 'inline-flex items-center justify-center rounded-full border border-white/70 px-6 py-2 font-montserrat text-sm font-bold uppercase tracking-wider text-white hover:border-white hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-cornflower'
+              : 'inline-flex items-center justify-center rounded-full border border-cornflower px-5 py-2 font-montserrat text-sm font-bold uppercase tracking-wider text-cornflower hover:bg-cornflower hover:text-white focus:outline-none focus:ring-2 focus:ring-cornflower focus:ring-offset-2'
+          }
+          to="/get-involved"
         >
-          Log In
+          How it Works
         </Link>
       </div>
     </section>

--- a/src/routes/PublicRoles.tsx
+++ b/src/routes/PublicRoles.tsx
@@ -63,11 +63,7 @@ const PublicRoles = () => {
       }
 
       if (needle.length > 0) {
-        const haystack = [
-          r.role_name,
-          r.offstage_role,
-          r.production_name
-        ]
+        const haystack = [r.role_name, r.offstage_role, r.production_name]
           .filter(Boolean)
           .join(' ')
           .toLowerCase();
@@ -132,8 +128,8 @@ const PublicRoles = () => {
       <>
         <p className="mb-4 font-montserrat text-sm text-grayishBlue">
           Showing {filteredRoles.length}
-          {hasActiveFilters ? ` of ${roles.length}` : ''}{' '}
-          open {filteredRoles.length === 1 ? 'role' : 'roles'}
+          {hasActiveFilters ? ` of ${roles.length}` : ''} open{' '}
+          {filteredRoles.length === 1 ? 'role' : 'roles'}
         </p>
         <div data-testid="public-roles-list">
           {filteredRoles.map((role, index) => (
@@ -147,6 +143,15 @@ const PublicRoles = () => {
             />
           ))}
         </div>
+        {/* Bottom CTA — reinforces sign-up after the visitor has scanned
+            the full list. Uses the lighter 'inline' variant so it reads as
+            a natural end-of-list nudge rather than a competing banner. */}
+        <PublicRolesSignUpCTA
+          body="Create a free profile so theatres can find you when they're casting."
+          className="mt-6"
+          heading="See a role that excites you?"
+          variant="inline"
+        />
       </>
     );
   };
@@ -162,8 +167,11 @@ const PublicRoles = () => {
 
           {/* Sign-up CTA appears above the list whenever we have roles to
               show. The empty-system null state has its own embedded CTA so
-              we don't double up. */}
-          {!loading && roles.length > 0 && <PublicRolesSignUpCTA />}
+              we don't double up. The 'banner' variant uses the cornflower
+              brand block so it's clearly distinct from role cards below. */}
+          {!loading && roles.length > 0 && (
+            <PublicRolesSignUpCTA variant="banner" />
+          )}
 
           {/* Filters are shown whenever there's at least one role in the
               system, otherwise filtering is meaningless. */}

--- a/src/test/PublicRoleCard.test.tsx
+++ b/src/test/PublicRoleCard.test.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import PublicRoleCard from '../components/PublicShows/PublicRoleCard';
+import type { Role } from '../components/Profile/Company/types';
+
+const baseRole: Role = {
+  role_id: 'r1',
+  role_name: 'Lead Actor',
+  type: 'On-Stage',
+  role_status: 'Open'
+};
+
+const renderCard = (
+  role: Role,
+  extras?: Partial<{
+    productionId: string;
+    productionName: string;
+    auditionStart: string;
+    auditionEnd: string;
+  }>
+) => {
+  return render(
+    <MemoryRouter>
+      <PublicRoleCard role={role} {...extras} />
+    </MemoryRouter>
+  );
+};
+
+describe('PublicRoleCard', () => {
+  it('renders role name', () => {
+    renderCard(baseRole);
+    expect(screen.getByText('Lead Actor')).toBeInTheDocument();
+  });
+
+  it('falls back to offstage_role when role_name is absent', () => {
+    renderCard({
+      ...baseRole,
+      role_name: undefined,
+      offstage_role: 'Stage Manager'
+    });
+    expect(screen.getByText('Stage Manager')).toBeInTheDocument();
+  });
+
+  it('shows "Untitled Role" when neither role_name nor offstage_role is set', () => {
+    renderCard({ ...baseRole, role_name: undefined, offstage_role: undefined });
+    expect(screen.getByText('Untitled Role')).toBeInTheDocument();
+  });
+
+  it('does not render the "Open" role status badge', () => {
+    // The API only returns Open roles; the badge would be redundant noise.
+    renderCard(baseRole);
+    expect(screen.queryByText('Open')).not.toBeInTheDocument();
+  });
+
+  describe('rate display', () => {
+    it('formats pay rate with dollar sign and unit — no "per Per" duplication', () => {
+      renderCard({ ...baseRole, role_rate: 500, role_rate_unit: 'Per Week' });
+      expect(screen.getByText('$500 Per Week')).toBeInTheDocument();
+      expect(screen.queryByText(/per Per/)).not.toBeInTheDocument();
+    });
+
+    it('shows rate without unit when unit is absent', () => {
+      renderCard({ ...baseRole, role_rate: 200 });
+      expect(screen.getByText('$200')).toBeInTheDocument();
+    });
+
+    it('shows rate when role_rate is 0 (free/volunteer)', () => {
+      renderCard({ ...baseRole, role_rate: 0 });
+      expect(screen.getByText('$0')).toBeInTheDocument();
+    });
+
+    it('hides rate section when role_rate is not set', () => {
+      renderCard({ ...baseRole, role_rate: undefined });
+      expect(screen.queryByText('Rate:')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('description truncation', () => {
+    it('renders a description when provided', () => {
+      renderCard({ ...baseRole, description: 'A short description' });
+      expect(screen.getByText('A short description')).toBeInTheDocument();
+    });
+
+    it('does not render description element when absent', () => {
+      renderCard({ ...baseRole, description: undefined });
+      expect(screen.queryByText(/description/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('list mode', () => {
+    it('shows production name as a link when productionId and productionName are present', () => {
+      renderCard(baseRole, {
+        productionId: 'p1',
+        productionName: 'Hamlet'
+      });
+      expect(screen.getByText('Hamlet')).toBeInTheDocument();
+      const productionLink = screen.getByRole('link', { name: 'Hamlet' });
+      expect(productionLink).toHaveAttribute('href', '/shows/p1');
+    });
+
+    it('shows a "View Production" button linking to the production page', () => {
+      renderCard(baseRole, {
+        productionId: 'p1',
+        productionName: 'Hamlet'
+      });
+      const viewBtn = screen.getByRole('button', { name: /view production/i });
+      expect(viewBtn).toBeInTheDocument();
+      const link = viewBtn.closest('a');
+      expect(link).toHaveAttribute('href', '/shows/p1');
+    });
+
+    it('does not show "View Production" button when not in list mode', () => {
+      renderCard(baseRole);
+      expect(
+        screen.queryByRole('button', { name: /view production/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides production name line when productionName is absent', () => {
+      renderCard(baseRole, { productionId: 'p1' });
+      // Production link should not exist without a name to display.
+      expect(
+        screen.queryByRole('link', { name: /shows\/p1/ })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('audition date window', () => {
+    it('renders the audition window when both dates are provided', () => {
+      renderCard(baseRole, {
+        productionId: 'p1',
+        auditionStart: '2026-06-01',
+        auditionEnd: '2026-06-15'
+      });
+      expect(screen.getByText('Auditions:')).toBeInTheDocument();
+      const container = screen.getByText('Auditions:').closest('div');
+      expect(container?.textContent).toContain('–');
+    });
+
+    it('does not render audition section when no dates are provided', () => {
+      renderCard(baseRole);
+      expect(screen.queryByText('Auditions:')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('detail chips', () => {
+    it('renders stage type', () => {
+      renderCard(baseRole);
+      expect(screen.getByText('Stage:')).toBeInTheDocument();
+      expect(screen.getByText('On-Stage')).toBeInTheDocument();
+    });
+
+    it('renders union information', () => {
+      renderCard({ ...baseRole, union: ['AEA', 'Non-Union'] });
+      expect(screen.getByText('Union:')).toBeInTheDocument();
+      expect(screen.getByText('AEA, Non-Union')).toBeInTheDocument();
+    });
+
+    it('hides union section when union array is empty', () => {
+      renderCard({ ...baseRole, union: [] });
+      expect(screen.queryByText('Union:')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/test/PublicRoles.test.tsx
+++ b/src/test/PublicRoles.test.tsx
@@ -82,14 +82,14 @@ describe('PublicRoles route', () => {
   it('shows a distinct error state when the fetch rejects (not the empty state)', async () => {
     // Suppress the expected console.error from the load() catch so the
     // test output stays clean.
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
     mockFetch.mockRejectedValueOnce(new Error('firestore unavailable'));
 
     renderRoute();
 
-    expect(
-      await screen.findByTestId('public-roles-error')
-    ).toBeInTheDocument();
+    expect(await screen.findByTestId('public-roles-error')).toBeInTheDocument();
     // Empty-state copy must NOT show — that would be misleading on a real
     // network/rules failure.
     expect(
@@ -108,10 +108,12 @@ describe('PublicRoles route', () => {
       await screen.findByTestId('public-roles-empty-state')
     ).toBeInTheDocument();
     expect(screen.getByText(/No open roles right now/i)).toBeInTheDocument();
-    // Sign-up CTA is embedded in the empty state.
-    const signUpLinks = screen.getAllByRole('link', { name: /sign up/i });
-    expect(signUpLinks.length).toBeGreaterThan(0);
-    expect(signUpLinks[0]).toHaveAttribute('href', '/sign-up');
+    // Sign-up CTA is embedded in the empty state — primary link goes to /sign-up.
+    const joinLinks = screen.getAllByRole('link', {
+      name: /create a free artist account/i
+    });
+    expect(joinLinks.length).toBeGreaterThan(0);
+    expect(joinLinks[0]).toHaveAttribute('href', '/sign-up');
   });
 
   it('shows the no-results null state when filters match nothing', async () => {
@@ -129,32 +131,41 @@ describe('PublicRoles route', () => {
       await screen.findByTestId('public-roles-no-results')
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/No matches for these filters/i)
+      screen.getByText(/No roles match your filters/i)
     ).toBeInTheDocument();
 
-    // Clearing filters should restore the list.
-    fireEvent.click(screen.getByRole('button', { name: /clear filters/i }));
+    // Clearing filters should restore the list. The button's accessible name
+    // comes from its aria-label ("Clear all active filters and show all roles").
+    fireEvent.click(
+      screen.getByRole('button', { name: /clear all active filters/i })
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Lead Actor')).toBeInTheDocument();
     });
   });
 
-  it('top sign-up CTA links to /sign-up and /login when roles exist', async () => {
+  it('top sign-up CTA links to /sign-up and /get-involved when roles exist', async () => {
     mockFetch.mockResolvedValueOnce(sampleRoles as never);
 
     renderRoute();
 
     await screen.findByText('Lead Actor');
 
-    const cta = screen.getByTestId('public-roles-signup-cta');
-    expect(cta).toBeInTheDocument();
+    // There are two sign-up CTAs (top banner + bottom inline); at least one
+    // of the primary links should point to /sign-up.
+    const allCtas = screen.getAllByTestId('public-roles-signup-cta');
+    expect(allCtas.length).toBeGreaterThanOrEqual(1);
 
-    const signUpLink = screen.getAllByRole('link', { name: /sign up/i })[0];
-    expect(signUpLink).toHaveAttribute('href', '/sign-up');
+    const joinLinks = screen.getAllByRole('link', {
+      name: /create a free artist account/i
+    });
+    expect(joinLinks[0]).toHaveAttribute('href', '/sign-up');
 
-    const loginLink = screen.getAllByRole('link', { name: /log in/i })[0];
-    expect(loginLink).toHaveAttribute('href', '/login');
+    const howItWorksLinks = screen.getAllByRole('link', {
+      name: /learn how chicago artist guide works/i
+    });
+    expect(howItWorksLinks[0]).toHaveAttribute('href', '/get-involved');
   });
 
   it('filters by stage type', async () => {

--- a/src/test/PublicRolesEmptyState.test.tsx
+++ b/src/test/PublicRolesEmptyState.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import PublicRolesEmptyState from '../components/PublicShows/PublicRolesEmptyState';
+
+const renderComponent = () =>
+  render(
+    <MemoryRouter>
+      <PublicRolesEmptyState />
+    </MemoryRouter>
+  );
+
+describe('PublicRolesEmptyState', () => {
+  it('renders the component without crashing', () => {
+    renderComponent();
+    expect(screen.getByTestId('public-roles-empty-state')).toBeInTheDocument();
+  });
+
+  it('displays the "no open roles" heading at h2 level', () => {
+    renderComponent();
+    const heading = screen.getByRole('heading', {
+      level: 2,
+      name: /no open roles right now/i
+    });
+    expect(heading).toBeInTheDocument();
+  });
+
+  it('renders friendly sub-copy that is warm and informative', () => {
+    renderComponent();
+    // Verifies the copy mentions checking back and regular posting.
+    expect(
+      screen.getByText(/check back soon|posted regularly|regularly/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders at least one /sign-up link inside the embedded CTA', () => {
+    renderComponent();
+    // Query by destination, not by visible text — the CTA copy is owned by
+    // PublicRolesSignUpCTA (DEV-498) and should be free to evolve.
+    const links = screen.getAllByRole('link');
+    const signUpLinks = links.filter(
+      (l) => l.getAttribute('href') === '/sign-up'
+    );
+    expect(signUpLinks.length).toBeGreaterThan(0);
+  });
+
+  it('renders a "Back to Home" navigation link', () => {
+    renderComponent();
+    // The link's accessible name comes from aria-label on the element.
+    const homeLink = screen.getByRole('link', {
+      name: /return to the chicago artist guide home page/i
+    });
+    expect(homeLink).toBeInTheDocument();
+    expect(homeLink).toHaveAttribute('href', '/');
+  });
+
+  it('does not render anything from the filter-driven no-results state', () => {
+    renderComponent();
+    // The filter-driven state (DEV-494) uses data-testid="public-roles-no-results".
+    expect(
+      screen.queryByTestId('public-roles-no-results')
+    ).not.toBeInTheDocument();
+    // The "Clear Filters" button belongs to DEV-494, not this component.
+    expect(
+      screen.queryByRole('button', { name: /clear filters/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the embedded sign-up CTA section', () => {
+    renderComponent();
+    expect(screen.getByTestId('public-roles-signup-cta')).toBeInTheDocument();
+  });
+
+  it('has an accessible heading hierarchy (h2 as primary heading)', () => {
+    renderComponent();
+    // h2 is appropriate here since the page title is an h1 rendered by the
+    // parent route (PublicRoles).
+    const h2Elements = screen.getAllByRole('heading', { level: 2 });
+    expect(h2Elements.length).toBeGreaterThanOrEqual(1);
+    expect(h2Elements[0]).toHaveTextContent(/no open roles right now/i);
+  });
+});

--- a/src/test/PublicRolesNoResults.test.tsx
+++ b/src/test/PublicRolesNoResults.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import PublicRolesNoResults from '../components/PublicShows/PublicRolesNoResults';
+
+const renderComponent = (onClearFilters = vi.fn()) =>
+  render(
+    <MemoryRouter>
+      <PublicRolesNoResults onClearFilters={onClearFilters} />
+    </MemoryRouter>
+  );
+
+describe('PublicRolesNoResults', () => {
+  it('renders the filtered null state with the correct heading', () => {
+    renderComponent();
+
+    expect(screen.getByTestId('public-roles-no-results')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /no roles match your filters/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders explanatory sub-copy that distinguishes it from the no-roles state', () => {
+    renderComponent();
+
+    // Should mention that roles exist but filters are hiding them.
+    expect(
+      screen.getByText(/there are open roles in the system/i)
+    ).toBeInTheDocument();
+  });
+
+  it('calls onClearFilters when the Clear Filters button is clicked', () => {
+    const onClearFilters = vi.fn();
+    renderComponent(onClearFilters);
+
+    const button = screen.getByRole('button', { name: /clear.*filters/i });
+    expect(button).toBeInTheDocument();
+
+    fireEvent.click(button);
+
+    expect(onClearFilters).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a secondary Sign Up link pointing to /sign-up', () => {
+    renderComponent();
+
+    const signUpLink = screen.getByTestId('no-results-signup-link');
+    expect(signUpLink).toBeInTheDocument();
+    expect(signUpLink).toHaveAttribute('href', '/sign-up');
+  });
+
+  it('does not render the "no roles at all" copy', () => {
+    renderComponent();
+
+    expect(
+      screen.queryByText(/no open roles right now/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/test/PublicRolesSignUpCTA.test.tsx
+++ b/src/test/PublicRolesSignUpCTA.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import PublicRolesSignUpCTA from '../components/PublicShows/PublicRolesSignUpCTA';
+
+const renderCTA = (
+  props: React.ComponentProps<typeof PublicRolesSignUpCTA> = {}
+) =>
+  render(
+    <MemoryRouter>
+      <PublicRolesSignUpCTA {...props} />
+    </MemoryRouter>
+  );
+
+describe('PublicRolesSignUpCTA', () => {
+  it('renders without crashing', () => {
+    renderCTA();
+    expect(screen.getByTestId('public-roles-signup-cta')).toBeInTheDocument();
+  });
+
+  it('primary CTA href points to /sign-up', () => {
+    renderCTA();
+    const primaryLink = screen.getByRole('link', {
+      name: /create a free artist account/i
+    });
+    expect(primaryLink).toHaveAttribute('href', '/sign-up');
+  });
+
+  it('secondary action href points to /get-involved', () => {
+    renderCTA();
+    const secondaryLink = screen.getByRole('link', {
+      name: /learn how chicago artist guide works/i
+    });
+    expect(secondaryLink).toHaveAttribute('href', '/get-involved');
+  });
+
+  it('renders default heading and body copy', () => {
+    renderCTA();
+    expect(screen.getByText(/Don.t miss your next role/i)).toBeInTheDocument();
+    expect(screen.getByText(/Build a free profile/i)).toBeInTheDocument();
+  });
+
+  it('accepts custom heading and body via props', () => {
+    renderCTA({
+      heading: 'Be the first to know',
+      body: 'Get an email the moment new roles are posted.'
+    });
+    expect(screen.getByText('Be the first to know')).toBeInTheDocument();
+    expect(
+      screen.getByText('Get an email the moment new roles are posted.')
+    ).toBeInTheDocument();
+  });
+
+  it('has distinct accessible section labels per variant (no duplicate landmarks)', () => {
+    const { unmount } = renderCTA();
+    expect(
+      screen.getByRole('region', { name: /sign up after browsing roles/i })
+    ).toBeInTheDocument();
+    unmount();
+
+    renderCTA({ variant: 'banner' });
+    expect(
+      screen.getByRole('region', { name: /sign up before browsing roles/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders banner variant with correct test id', () => {
+    renderCTA({ variant: 'banner' });
+    expect(screen.getByTestId('public-roles-signup-cta')).toBeInTheDocument();
+    // Banner variant still contains the primary /sign-up link.
+    expect(
+      screen.getByRole('link', { name: /create a free artist account/i })
+    ).toHaveAttribute('href', '/sign-up');
+  });
+
+  it('renders inline variant with correct test id', () => {
+    renderCTA({ variant: 'inline' });
+    expect(screen.getByTestId('public-roles-signup-cta')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Four ticket-scoped follow-ups to the public `/roles` page that shipped via PR #315 (DEV-496) + PR #316. One commit per ticket; each squashed implementation + review-fix.

## Tickets in this batch

- **DEV-494** — Friendly filter-empty state with accessible-contrast Clear Filters + Sign Up actions
- **DEV-495** — Friendly empty state for "no roles in the system at all" (distinct from the filter-empty case)
- **DEV-497** — `PublicRoleCard` layout/logic fixes (rate formatting bug, redundant Open badge removed, button consistency, skeleton truthful to actual layout)
- **DEV-498** — Sign-up CTA component with `banner` + `inline` variants, two placements (above filters, after the role list), accessible contrast, distinct landmark labels

Original sub-team agents reviewed cross-cutting by validator + correctness reviewer + adversarial bug hunter. Real findings folded back in before push (see Review Fixes below).

## Review fixes folded in

- **DEV-495**: removed broken `/theatre-companies` link (route doesn't exist) and switched the embedded sign-up CTA test to query by `href` so it survives DEV-498's CTA copy changes.
- **DEV-498**: distinct `aria-label` per variant ("Sign up before browsing roles" / "Sign up after browsing roles") so screen-reader landmark navigation can disambiguate the two CTAs on the same page; primary buttons recolored from `bg-mint`/`bg-salmon` (white text, 2.39:1 / 2.92:1, failed AA) to `bg-darkPrimary` and `bg-white text-darkPrimary` (7.4:1 / 7.6:1, AAA).
- **DEV-494**: same contrast fix on Clear Filters (`bg-mint` 2.39:1 → `bg-darkPrimary` 7.4:1) and Sign Up secondary link (`text-mint` → `text-darkPrimary`).
- **DEV-497**: skeleton `:nth-child(3)` selector was matching the FIRST description line; fixed to `:nth-child(4)` so the shorter width and larger margin land on the SECOND description (immediately above the chip row).

## Known deferred (not addressed here, worth their own tickets)

- **DEV-498**: CTA renders for authenticated users too. UX call — always-show vs auth-suppress vs different copy for signed-in users. No regression; the original PR #315 skeleton had the same behavior.
- **DEV-497**: nested `<Link><button>` follows the pre-existing pattern in `PublicShowCard.tsx`. Invalid HTML (interactive content nested inside a link) and creates two focusable elements per card going to identical destinations. Should be fixed alongside `PublicShowCard` for consistency rather than diverging here.
- Split `PublicShowDetail` effect to skip redundant production re-fetch on auth resolve (carry-over from PR #316 review).
- One-time backfill script for `theater_name` on legacy productions (carry-over).
- LGL constituent API CORS during signup (separate area).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — passes (Husky pre-commit ran on each commit)
- [x] Vitest:
  - `PublicRolesNoResults.test.tsx` — 5/5
  - `PublicRolesEmptyState.test.tsx` — 8/8
  - `PublicRoleCard.test.tsx` — 19/19
  - `PublicRolesSignUpCTA.test.tsx` — 8/8
  - `PublicRoles.test.tsx` (integration) — 6/6
  - **46 total green**
- [ ] Smoke test on staging once deployed:
  - `/roles` with filters that match nothing → DEV-494 state, Clear Filters resets and restores list
  - `/roles` with zero roles in the system → DEV-495 state (use a clean Firestore env)
  - `/roles` with roles → DEV-497 cards render correct rate format ("$50 Per Week", not "$50 per Per Week"), no "Open" badge, View Production button works
  - DEV-498 CTAs: top banner + bottom inline both navigate to `/sign-up`; no duplicate landmark warnings in axe DevTools