### PR TITLE
[DEV-499/DEV-500] Public roles filter drawer

### DIFF
--- a/src/components/PublicShows/FilterSection.tsx
+++ b/src/components/PublicShows/FilterSection.tsx
@@ -1,0 +1,103 @@
+import { faCheck, faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import clsx from 'clsx';
+import React, { useState } from 'react';
+
+export interface CheckboxFilterOption {
+  label?: string;
+  value: string;
+}
+
+interface CheckboxFilterGroupProps {
+  name: string;
+  onToggle: (value: string, checked: boolean) => void;
+  options: CheckboxFilterOption[];
+  selected: string[];
+}
+
+interface FilterSectionProps {
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+  title: string;
+}
+
+export const CheckboxFilterGroup: React.FC<CheckboxFilterGroupProps> = ({
+  name,
+  onToggle,
+  options,
+  selected
+}) => (
+  <div className="flex flex-col gap-2">
+    {options.map((option) => {
+      const checked = selected.includes(option.value);
+      const inputId = `${name}-${option.value}`
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-');
+
+      return (
+        <label
+          className="flex min-h-[44px] cursor-pointer items-center gap-3 font-montserrat text-base text-dark sm:text-lg"
+          htmlFor={inputId}
+          key={option.value}
+        >
+          <input
+            checked={checked}
+            className="peer sr-only"
+            id={inputId}
+            onChange={(e) => onToggle(option.value, e.target.checked)}
+            type="checkbox"
+          />
+          <span
+            aria-hidden="true"
+            className={clsx(
+              'flex h-8 w-8 flex-shrink-0 items-center justify-center rounded border bg-white text-lg transition-colors peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-mint peer-focus-visible:ring-offset-2',
+              {
+                'border-dark text-mint': checked,
+                'border-lightGrey text-transparent': !checked
+              }
+            )}
+          >
+            {checked && <FontAwesomeIcon icon={faCheck} />}
+          </span>
+          <span>{option.label || option.value}</span>
+        </label>
+      );
+    })}
+  </div>
+);
+
+const FilterSection: React.FC<FilterSectionProps> = ({
+  children,
+  defaultOpen = false,
+  title
+}) => {
+  const [open, setOpen] = useState(defaultOpen);
+  const contentId = `filter-section-${title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')}`;
+
+  return (
+    <section className="overflow-hidden rounded-lg border border-gold bg-filterCream">
+      <button
+        aria-controls={contentId}
+        aria-expanded={open}
+        className="flex min-h-[64px] w-full items-center justify-between gap-4 px-4 text-left font-montserrat text-xl font-semibold tracking-[0.08em] text-mainFont focus:outline-none focus-visible:ring-2 focus-visible:ring-mint focus-visible:ring-inset"
+        onClick={() => setOpen((current) => !current)}
+        type="button"
+      >
+        <span>{title}</span>
+        <FontAwesomeIcon icon={open ? faChevronUp : faChevronDown} />
+      </button>
+      {open && (
+        <div
+          className="border-t border-gold px-4 py-4"
+          id={contentId}
+        >
+          {children}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default FilterSection;

--- a/src/components/PublicShows/PublicRolesFilters.tsx
+++ b/src/components/PublicShows/PublicRolesFilters.tsx
@@ -1,68 +1,33 @@
+import { faFilter } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 
-export type StageFilter = 'All' | 'On-Stage' | 'Off-Stage';
-
 interface PublicRolesFiltersProps {
-  searchTerm: string;
-  stageFilter: StageFilter;
-  onSearchChange: (value: string) => void;
-  onStageFilterChange: (value: StageFilter) => void;
+  appliedCount: number;
+  onOpen: () => void;
+  triggerRef?: React.Ref<HTMLButtonElement>;
 }
 
-const STAGE_OPTIONS: StageFilter[] = ['All', 'On-Stage', 'Off-Stage'];
-
 const PublicRolesFilters: React.FC<PublicRolesFiltersProps> = ({
-  searchTerm,
-  stageFilter,
-  onSearchChange,
-  onStageFilterChange
+  appliedCount,
+  onOpen,
+  triggerRef
 }) => {
   return (
-    <div
-      className="mb-6 rounded-lg bg-white p-4 shadow-sm"
-      data-testid="public-roles-filters"
-    >
-      <div className="flex flex-col gap-4 md:flex-row md:items-end">
-        <div className="flex-1">
-          <label
-            className="mb-1 block font-montserrat text-xs font-semibold uppercase tracking-wider text-darkGrey"
-            htmlFor="public-roles-search"
-          >
-            Search
-          </label>
-          <input
-            aria-label="Search roles by name or production"
-            className="w-full rounded-md border border-lightGrey bg-bodyBg px-3 py-2 font-montserrat text-sm text-darkGrey focus:border-mint focus:outline-none focus:ring-1 focus:ring-mint"
-            id="public-roles-search"
-            onChange={(e) => onSearchChange(e.target.value)}
-            placeholder="Search by role or production"
-            type="text"
-            value={searchTerm}
-          />
-        </div>
-
-        <div>
-          <label
-            className="mb-1 block font-montserrat text-xs font-semibold uppercase tracking-wider text-darkGrey"
-            htmlFor="public-roles-stage-filter"
-          >
-            Stage Type
-          </label>
-          <select
-            aria-label="Filter by stage type"
-            className="w-full rounded-md border border-lightGrey bg-bodyBg px-3 py-2 font-montserrat text-sm text-darkGrey focus:border-mint focus:outline-none focus:ring-1 focus:ring-mint md:w-48"
-            id="public-roles-stage-filter"
-            onChange={(e) => onStageFilterChange(e.target.value as StageFilter)}
-            value={stageFilter}
-          >
-            {STAGE_OPTIONS.map((opt) => (
-              <option key={opt} value={opt}>
-                {opt}
-              </option>
-            ))}
-          </select>
-        </div>
-      </div>
+    <div className="mb-6 mt-8" data-testid="public-roles-filters">
+      <button
+        aria-label={`Filter roles, ${appliedCount} applied`}
+        className="inline-flex min-h-[48px] items-center gap-2 rounded-full bg-cornflower px-5 font-montserrat text-sm font-bold uppercase tracking-[0.12em] text-white shadow-md transition-colors hover:bg-darkGreyBlue focus:outline-none focus:ring-2 focus:ring-cornflower focus:ring-offset-2"
+        onClick={onOpen}
+        ref={triggerRef}
+        type="button"
+      >
+        <span>Filter Roles</span>
+        <span className="font-medium normal-case tracking-[0.02em]">
+          ({appliedCount} applied)
+        </span>
+        <FontAwesomeIcon icon={faFilter} />
+      </button>
     </div>
   );
 };

--- a/src/components/PublicShows/PublicRolesNoResults.tsx
+++ b/src/components/PublicShows/PublicRolesNoResults.tsx
@@ -20,9 +20,9 @@ const PublicRolesNoResults: React.FC<PublicRolesNoResultsProps> = ({
         No roles match your filters
       </h2>
       <p className="mx-auto mt-3 max-w-md font-montserrat text-base text-grayishBlue">
-        There are open roles in the system, but none match your current search
-        or stage-type filter. Try broadening your search or clearing all filters
-        to see every available opportunity.
+        There are open roles in the system, but none match your current
+        filters. Try broadening your selections or clearing all filters to see
+        every available opportunity.
       </p>
       <div className="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
         <button

--- a/src/components/PublicShows/RolesFilterDrawer.tsx
+++ b/src/components/PublicShows/RolesFilterDrawer.tsx
@@ -1,0 +1,417 @@
+import {
+  faTimes
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import clsx from 'clsx';
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  additionalRequirements,
+  ageRanges,
+  ethnicities,
+  roleGenders,
+  stageRoles,
+  unionOptionLabels,
+  unionOptions
+} from '../../utils/lookups';
+import FilterSection, {
+  CheckboxFilterGroup,
+  CheckboxFilterOption
+} from './FilterSection';
+import { countAppliedFilters } from './roleFilters';
+import type { RoleFilters } from './roleFilters';
+
+interface RolesFilterDrawerProps {
+  draft: RoleFilters;
+  onApply: () => void;
+  onChange: (next: RoleFilters) => void;
+  onClear: () => void;
+  onClose: () => void;
+  open: boolean;
+}
+
+type MultiFilterField =
+  | 'genders'
+  | 'ageRanges'
+  | 'ethnicities'
+  | 'unions'
+  | 'requirements';
+
+const focusableSelector = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])'
+].join(',');
+
+const toOptions = (options: readonly string[]): CheckboxFilterOption[] =>
+  options.map((value) => ({ value }));
+
+const parsePayValue = (value: string) => {
+  const normalized = value.replace(/[$,]/g, '').trim();
+
+  if (!normalized) {
+    return undefined;
+  }
+
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const getFocusableElements = (container: HTMLDivElement | null) => {
+  if (!container) {
+    return [];
+  }
+
+  return Array.from(container.querySelectorAll<HTMLElement>(focusableSelector))
+    .filter((element) => element.offsetParent !== null);
+};
+
+const RolesFilterDrawer: React.FC<RolesFilterDrawerProps> = ({
+  draft,
+  onApply,
+  onChange,
+  onClear,
+  onClose,
+  open
+}) => {
+  const [active, setActive] = useState(false);
+  const [rendered, setRendered] = useState(open);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+  const previousOverflowRef = useRef('');
+  const titleId = 'roles-filter-drawer-title';
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    if (open) {
+      setRendered(true);
+      const frame = window.requestAnimationFrame(() => setActive(true));
+      return () => window.cancelAnimationFrame(frame);
+    }
+
+    setActive(false);
+    const timeout = window.setTimeout(() => setRendered(false), 200);
+    return () => window.clearTimeout(timeout);
+  }, [open]);
+
+  useEffect(() => {
+    if (!rendered) {
+      return undefined;
+    }
+
+    previousOverflowRef.current = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previousOverflowRef.current;
+    };
+  }, [rendered]);
+
+  useEffect(() => {
+    if (!open || !rendered) {
+      return undefined;
+    }
+
+    const previousFocus = document.activeElement as HTMLElement | null;
+    const focusFrame = window.requestAnimationFrame(() => {
+      panelRef.current?.focus();
+    });
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onCloseRef.current();
+        return;
+      }
+
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const focusable = getFocusableElements(panelRef.current);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.cancelAnimationFrame(focusFrame);
+      document.removeEventListener('keydown', handleKeyDown);
+
+      if (previousFocus && document.contains(previousFocus)) {
+        previousFocus.focus();
+      }
+    };
+  }, [open, rendered]);
+
+  if (!rendered) {
+    return null;
+  }
+
+  const draftCount = countAppliedFilters(draft);
+
+  const updateMultiFilter = (
+    field: MultiFilterField,
+    value: string,
+    checked: boolean
+  ) => {
+    const selected = draft[field];
+    const nextValues = checked
+      ? [...selected, value]
+      : selected.filter((selectedValue) => selectedValue !== value);
+
+    onChange({
+      ...draft,
+      [field]: nextValues
+    });
+  };
+
+  const updatePayFilter = (field: 'payMin' | 'payMax', value: string) => {
+    onChange({
+      ...draft,
+      [field]: parsePayValue(value)
+    });
+  };
+
+  const unionFilterOptions = unionOptions.map((option) => ({
+    label: unionOptionLabels[option],
+    value: option
+  }));
+
+  return createPortal(
+    <div className="fixed inset-0 z-[1050]">
+      <div
+        aria-hidden="true"
+        className={clsx(
+          'absolute inset-0 bg-black/50 transition-opacity duration-200',
+          {
+            'opacity-0': !active,
+            'opacity-100': active
+          }
+        )}
+        onClick={() => onCloseRef.current()}
+      />
+      <div
+        aria-labelledby={titleId}
+        aria-modal="true"
+        className={clsx(
+          'fixed right-0 top-0 flex h-[100dvh] w-full transform flex-col bg-white shadow-2xl transition-transform duration-200 ease-out md:w-[47vw] md:min-w-[400px] md:max-w-[680px]',
+          {
+            'translate-x-0': active,
+            'translate-x-full': !active
+          }
+        )}
+        ref={panelRef}
+        role="dialog"
+        tabIndex={-1}
+      >
+        <div className="flex min-h-[76px] flex-shrink-0 items-center justify-between bg-cornflower px-7 text-white md:px-12">
+          <h2
+            className="m-0 font-montserrat text-2xl font-medium uppercase tracking-[0.08em] !text-white"
+            id={titleId}
+          >
+            Filter Roles
+          </h2>
+          <button
+            aria-label="Close filter roles"
+            className="flex h-11 w-11 items-center justify-center rounded-full text-2xl text-white transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-cornflower"
+            onClick={() => onCloseRef.current()}
+            type="button"
+          >
+            <FontAwesomeIcon icon={faTimes} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-6 py-8 md:px-6">
+          <div className="space-y-6">
+            <div>
+              <label
+                className="mb-2 block font-montserrat text-xl font-semibold tracking-[0.08em] text-mainFont"
+                htmlFor="roles-filter-role-type"
+              >
+                Role Type
+              </label>
+              <select
+                aria-label="Filter by role type"
+                className="h-12 w-full rounded border border-lightGrey bg-white px-3 font-montserrat text-xl text-dark focus:border-mint focus:outline-none focus:ring-1 focus:ring-mint"
+                id="roles-filter-role-type"
+                onChange={(e) =>
+                  onChange({
+                    ...draft,
+                    roleType: e.target.value
+                      ? (e.target.value as RoleFilters['roleType'])
+                      : undefined
+                  })
+                }
+                value={draft.roleType || ''}
+              >
+                <option value="">Select..</option>
+                {stageRoles.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <FilterSection
+              defaultOpen={draft.genders.length > 0}
+              title="Role Gender"
+            >
+              <CheckboxFilterGroup
+                name="role-gender"
+                onToggle={(value, checked) =>
+                  updateMultiFilter('genders', value, checked)
+                }
+                options={toOptions(roleGenders)}
+                selected={draft.genders}
+              />
+            </FilterSection>
+
+            <FilterSection
+              defaultOpen={draft.ageRanges.length > 0}
+              title="Role Age Range"
+            >
+              <CheckboxFilterGroup
+                name="role-age-range"
+                onToggle={(value, checked) =>
+                  updateMultiFilter('ageRanges', value, checked)
+                }
+                options={toOptions(ageRanges)}
+                selected={draft.ageRanges}
+              />
+            </FilterSection>
+
+            <FilterSection
+              defaultOpen={draft.ethnicities.length > 0}
+              title="Ethnicity"
+            >
+              <CheckboxFilterGroup
+                name="role-ethnicity"
+                onToggle={(value, checked) =>
+                  updateMultiFilter('ethnicities', value, checked)
+                }
+                options={toOptions(ethnicities)}
+                selected={draft.ethnicities}
+              />
+            </FilterSection>
+
+            <FilterSection
+              defaultOpen={draft.unions.length > 0}
+              title="Union Status"
+            >
+              <CheckboxFilterGroup
+                name="role-union-status"
+                onToggle={(value, checked) =>
+                  updateMultiFilter('unions', value, checked)
+                }
+                options={unionFilterOptions}
+                selected={draft.unions}
+              />
+            </FilterSection>
+
+            <FilterSection
+              defaultOpen={draft.requirements.length > 0}
+              title="Additional Requirements"
+            >
+              <CheckboxFilterGroup
+                name="role-additional-requirements"
+                onToggle={(value, checked) =>
+                  updateMultiFilter('requirements', value, checked)
+                }
+                options={toOptions(additionalRequirements)}
+                selected={draft.requirements}
+              />
+            </FilterSection>
+
+            <div>
+              <h3 className="mb-3 font-montserrat text-xl font-semibold tracking-[0.08em] text-mainFont">
+                Pay Range
+              </h3>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div>
+                  <label
+                    className="mb-1 block font-montserrat text-sm font-semibold tracking-[0.04em] text-dark"
+                    htmlFor="roles-filter-pay-min"
+                  >
+                    Minimum
+                  </label>
+                  <input
+                    className="h-12 w-full rounded border border-lightGrey bg-white px-3 font-montserrat text-lg text-dark focus:border-mint focus:outline-none focus:ring-1 focus:ring-mint"
+                    id="roles-filter-pay-min"
+                    inputMode="numeric"
+                    min="0"
+                    onChange={(e) => updatePayFilter('payMin', e.target.value)}
+                    placeholder="$0"
+                    type="number"
+                    value={draft.payMin ?? ''}
+                  />
+                </div>
+                <div>
+                  <label
+                    className="mb-1 block font-montserrat text-sm font-semibold tracking-[0.04em] text-dark"
+                    htmlFor="roles-filter-pay-max"
+                  >
+                    Maximum
+                  </label>
+                  <input
+                    className="h-12 w-full rounded border border-lightGrey bg-white px-3 font-montserrat text-lg text-dark focus:border-mint focus:outline-none focus:ring-1 focus:ring-mint"
+                    id="roles-filter-pay-max"
+                    inputMode="numeric"
+                    min="0"
+                    onChange={(e) => updatePayFilter('payMax', e.target.value)}
+                    placeholder="$10,000"
+                    type="number"
+                    value={draft.payMax ?? ''}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div
+          className="flex flex-shrink-0 flex-col items-center border-t border-lightGrey bg-white px-5 pt-8 shadow-[0_-4px_20px_rgba(0,0,0,0.08)]"
+          style={{ paddingBottom: 'max(1.5rem, env(safe-area-inset-bottom))' }}
+        >
+          <button
+            className="min-h-[52px] w-full rounded-full bg-salmon px-8 font-montserrat text-xl font-bold uppercase tracking-[0.12em] text-white shadow-lg transition-colors hover:bg-[#cf6f56] focus:outline-none focus:ring-2 focus:ring-salmon focus:ring-offset-2"
+            onClick={onApply}
+            type="button"
+          >
+            Apply Filters
+          </button>
+          <button
+            className="mt-4 min-h-[44px] font-montserrat text-base font-bold tracking-[0.08em] text-dark underline focus:outline-none focus:ring-2 focus:ring-mint focus:ring-offset-2"
+            onClick={onClear}
+            type="button"
+          >
+            Clear all filters{draftCount > 0 ? ` (${draftCount})` : ''}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default RolesFilterDrawer;

--- a/src/components/PublicShows/roleFilters.test.ts
+++ b/src/components/PublicShows/roleFilters.test.ts
@@ -1,0 +1,167 @@
+import type { PublicRoleListItem } from './api';
+import {
+  applyRoleFilters,
+  countAppliedFilters,
+  createEmptyRoleFilters
+} from './roleFilters';
+import type { RoleFilters } from './roleFilters';
+
+const makeRole = (
+  overrides: Partial<PublicRoleListItem> = {}
+): PublicRoleListItem =>
+  ({
+    account_id: 'account-1',
+    production_id: 'production-1',
+    production_name: 'Test Production',
+    role_id: 'role-1',
+    role_name: 'Test Role',
+    role_status: 'Open',
+    type: 'On-Stage',
+    ...overrides
+  }) as PublicRoleListItem;
+
+const makeFilters = (overrides: Partial<RoleFilters> = {}): RoleFilters => ({
+  ...createEmptyRoleFilters(),
+  ...overrides
+});
+
+describe('roleFilters', () => {
+  it('returns every role when no filters are active', () => {
+    const roles = [
+      makeRole({ role_id: 'r1' }),
+      makeRole({ role_id: 'r2', type: 'Off-Stage' })
+    ];
+
+    expect(applyRoleFilters(roles, createEmptyRoleFilters())).toEqual(roles);
+  });
+
+  it('filters by role type', () => {
+    const roles = [
+      makeRole({ role_id: 'r1', type: 'On-Stage' }),
+      makeRole({ role_id: 'r2', type: 'Off-Stage' })
+    ];
+
+    expect(
+      applyRoleFilters(roles, makeFilters({ roleType: 'Off-Stage' }))
+    ).toEqual([roles[1]]);
+  });
+
+  it('uses OR within a section and AND across sections', () => {
+    const roles = [
+      makeRole({
+        role_id: 'r1',
+        age_range: ['18-22'],
+        gender_identity: ['Woman']
+      }),
+      makeRole({
+        role_id: 'r2',
+        age_range: ['23-27'],
+        gender_identity: ['Man']
+      }),
+      makeRole({
+        role_id: 'r3',
+        age_range: ['33-37'],
+        gender_identity: ['Woman']
+      })
+    ];
+
+    expect(
+      applyRoleFilters(
+        roles,
+        makeFilters({
+          ageRanges: ['18-22', '23-27'],
+          genders: ['Woman', 'Man']
+        })
+      )
+    ).toEqual([roles[0], roles[1]]);
+  });
+
+  it('keeps open-to-all matching literal', () => {
+    const roles = [
+      makeRole({
+        role_id: 'r1',
+        gender_identity: ['Open to all genders']
+      }),
+      makeRole({ role_id: 'r2', gender_identity: ['Man'] })
+    ];
+
+    expect(
+      applyRoleFilters(roles, makeFilters({ genders: ['Man'] }))
+    ).toEqual([roles[1]]);
+
+    expect(
+      applyRoleFilters(
+        roles,
+        makeFilters({ genders: ['Open to all genders'] })
+      )
+    ).toEqual([roles[0]]);
+  });
+
+  it('matches legacy and trans/nonbinary gender storage', () => {
+    const roles = [
+      makeRole({
+        include_nonbinary: true,
+        role_id: 'r1',
+        gender_identity: ['Woman']
+      }),
+      makeRole({
+        role_id: 'r2',
+        gender_identity: ['Trans/Nonbinary'],
+        trans_nonbinary_roles: ['Man']
+      })
+    ];
+
+    expect(
+      applyRoleFilters(roles, makeFilters({ genders: ['Nonbinary'] }))
+    ).toEqual([roles[0]]);
+
+    expect(
+      applyRoleFilters(roles, makeFilters({ genders: ['Man'] }))
+    ).toEqual([roles[1]]);
+  });
+
+  it('expands ethnicity values for matching', () => {
+    const roles = [
+      makeRole({
+        ethnicity: ['East Asian (ex. China, Korea, Japan)'],
+        role_id: 'r1'
+      }),
+      makeRole({
+        ethnicity: ['White'],
+        role_id: 'r2'
+      })
+    ];
+
+    expect(
+      applyRoleFilters(roles, makeFilters({ ethnicities: ['Asian'] }))
+    ).toEqual([roles[0]]);
+  });
+
+  it('filters pay bounds and excludes missing rates when pay is active', () => {
+    const roles = [
+      makeRole({ role_id: 'r1', role_rate: 50 }),
+      makeRole({
+        role_id: 'r2',
+        role_rate: '$600' as unknown as number
+      }),
+      makeRole({ role_id: 'r3' })
+    ];
+
+    expect(
+      applyRoleFilters(roles, makeFilters({ payMin: 100, payMax: 700 }))
+    ).toEqual([roles[1]]);
+  });
+
+  it('counts selected values and pay as one applied filter', () => {
+    expect(
+      countAppliedFilters(
+        makeFilters({
+          ageRanges: ['18-22', '23-27', '28-32'],
+          genders: ['Open to all genders'],
+          payMin: 100,
+          roleType: 'On-Stage'
+        })
+      )
+    ).toBe(6);
+  });
+});

--- a/src/components/PublicShows/roleFilters.ts
+++ b/src/components/PublicShows/roleFilters.ts
@@ -1,0 +1,180 @@
+import type { StageRole } from '../Profile/shared/profile.types';
+import { expandEthnicityForMatching } from '../../utils/helpers';
+import type { PublicRoleListItem } from './api';
+
+export interface RoleFilters {
+  roleType?: Extract<StageRole, 'On-Stage' | 'Off-Stage'>;
+  genders: string[];
+  ageRanges: string[];
+  ethnicities: string[];
+  unions: string[];
+  requirements: string[];
+  payMin?: number;
+  payMax?: number;
+}
+
+export const EMPTY_FILTERS: RoleFilters = {
+  genders: [],
+  ageRanges: [],
+  ethnicities: [],
+  unions: [],
+  requirements: []
+};
+
+export const createEmptyRoleFilters = (): RoleFilters => ({
+  genders: [],
+  ageRanges: [],
+  ethnicities: [],
+  unions: [],
+  requirements: []
+});
+
+export const cloneRoleFilters = (filters: RoleFilters): RoleFilters => ({
+  roleType: filters.roleType,
+  genders: [...filters.genders],
+  ageRanges: [...filters.ageRanges],
+  ethnicities: [...filters.ethnicities],
+  unions: [...filters.unions],
+  requirements: [...filters.requirements],
+  payMin: filters.payMin,
+  payMax: filters.payMax
+});
+
+const hasValue = (values: string[] | undefined, selected: string[]) => {
+  if (selected.length === 0) {
+    return true;
+  }
+
+  if (!Array.isArray(values) || values.length === 0) {
+    return false;
+  }
+
+  return selected.some((value) => values.includes(value));
+};
+
+const getRoleGenderValues = (role: PublicRoleListItem) => {
+  const genders = Array.isArray(role.gender_identity)
+    ? [...role.gender_identity]
+    : [];
+
+  if (role.include_nonbinary && !genders.includes('Nonbinary')) {
+    genders.push('Nonbinary');
+  }
+
+  if (genders.includes('Trans/Nonbinary')) {
+    const transRoles = Array.isArray(role.trans_nonbinary_roles)
+      ? role.trans_nonbinary_roles
+      : [];
+
+    if (transRoles.length === 0 && !genders.includes('Nonbinary')) {
+      genders.push('Nonbinary');
+    }
+
+    transRoles.forEach((gender) => {
+      if (!genders.includes(gender)) {
+        genders.push(gender);
+      }
+    });
+  }
+
+  return genders;
+};
+
+const getRoleRate = (role: PublicRoleListItem) => {
+  const value = role.role_rate as unknown;
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value.replace(/[$,]/g, '').trim());
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  return undefined;
+};
+
+const hasPayFilter = (filters: RoleFilters) =>
+  filters.payMin != null || filters.payMax != null;
+
+const passesPayFilter = (role: PublicRoleListItem, filters: RoleFilters) => {
+  if (!hasPayFilter(filters)) {
+    return true;
+  }
+
+  const rate = getRoleRate(role);
+
+  if (rate == null) {
+    return false;
+  }
+
+  if (filters.payMin != null && rate < filters.payMin) {
+    return false;
+  }
+
+  if (filters.payMax != null && rate > filters.payMax) {
+    return false;
+  }
+
+  return true;
+};
+
+const hasEthnicityMatch = (
+  values: string[] | undefined,
+  selectedEthnicities: string[]
+) => {
+  if (selectedEthnicities.length === 0) {
+    return true;
+  }
+
+  if (!Array.isArray(values) || values.length === 0) {
+    return false;
+  }
+
+  const expandedValues = expandEthnicityForMatching(values);
+  const expandedSelected = expandEthnicityForMatching(selectedEthnicities);
+
+  return expandedSelected.some((value) => expandedValues.includes(value));
+};
+
+export const countAppliedFilters = (filters: RoleFilters) =>
+  (filters.roleType ? 1 : 0) +
+  filters.genders.length +
+  filters.ageRanges.length +
+  filters.ethnicities.length +
+  filters.unions.length +
+  filters.requirements.length +
+  (hasPayFilter(filters) ? 1 : 0);
+
+export const applyRoleFilters = (
+  roles: PublicRoleListItem[],
+  filters: RoleFilters
+) =>
+  roles.filter((role) => {
+    if (filters.roleType && role.type !== filters.roleType) {
+      return false;
+    }
+
+    if (!hasValue(getRoleGenderValues(role), filters.genders)) {
+      return false;
+    }
+
+    if (!hasValue(role.age_range, filters.ageRanges)) {
+      return false;
+    }
+
+    if (!hasEthnicityMatch(role.ethnicity, filters.ethnicities)) {
+      return false;
+    }
+
+    if (!hasValue(role.union, filters.unions)) {
+      return false;
+    }
+
+    if (!hasValue(role.additional_requirements, filters.requirements)) {
+      return false;
+    }
+
+    return passesPayFilter(role, filters);
+  });

--- a/src/routes/PublicRoles.tsx
+++ b/src/routes/PublicRoles.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import { Col, Row } from 'react-bootstrap';
 import { PageContainer } from '../components/layout';
 import { Tagline, Title } from '../components/layout/Titles';
@@ -9,9 +15,16 @@ import PublicRoleCard from '../components/PublicShows/PublicRoleCard';
 import PublicRoleCardSkeleton from '../components/PublicShows/PublicRoleCardSkeleton';
 import PublicRolesEmptyState from '../components/PublicShows/PublicRolesEmptyState';
 import PublicRolesFilters from '../components/PublicShows/PublicRolesFilters';
-import type { StageFilter } from '../components/PublicShows/PublicRolesFilters';
 import PublicRolesNoResults from '../components/PublicShows/PublicRolesNoResults';
 import PublicRolesSignUpCTA from '../components/PublicShows/PublicRolesSignUpCTA';
+import RolesFilterDrawer from '../components/PublicShows/RolesFilterDrawer';
+import {
+  applyRoleFilters,
+  cloneRoleFilters,
+  countAppliedFilters,
+  createEmptyRoleFilters
+} from '../components/PublicShows/roleFilters';
+import type { RoleFilters } from '../components/PublicShows/roleFilters';
 
 // Roles list page (DEV-496/494/495/497/498). Renders every Open role
 // across active productions, lets unauth visitors filter, and offers a
@@ -21,8 +34,12 @@ const PublicRoles = () => {
   const [roles, setRoles] = useState<PublicRoleListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [stageFilter, setStageFilter] = useState<StageFilter>('All');
+  const [appliedFilters, setAppliedFilters] =
+    useState<RoleFilters>(createEmptyRoleFilters);
+  const [draftFilters, setDraftFilters] =
+    useState<RoleFilters>(createEmptyRoleFilters);
+  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
+  const filterTriggerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     let isMounted = true;
@@ -54,36 +71,45 @@ const PublicRoles = () => {
     };
   }, [firebaseFirestore]);
 
-  const filteredRoles = useMemo(() => {
-    const needle = searchTerm.trim().toLowerCase();
+  const filteredRoles = useMemo(
+    () => applyRoleFilters(roles, appliedFilters),
+    [appliedFilters, roles]
+  );
 
-    return roles.filter((r) => {
-      if (stageFilter !== 'All' && r.type !== stageFilter) {
-        return false;
-      }
+  const appliedFilterCount = useMemo(
+    () => countAppliedFilters(appliedFilters),
+    [appliedFilters]
+  );
 
-      if (needle.length > 0) {
-        const haystack = [r.role_name, r.offstage_role, r.production_name]
-          .filter(Boolean)
-          .join(' ')
-          .toLowerCase();
+  const filteredProductionCount = useMemo(
+    () => new Set(filteredRoles.map((role) => role.production_id)).size,
+    [filteredRoles]
+  );
 
-        if (!haystack.includes(needle)) {
-          return false;
-        }
-      }
+  const clearFilters = useCallback(() => {
+    setAppliedFilters(createEmptyRoleFilters());
+    setDraftFilters(createEmptyRoleFilters());
+  }, []);
 
-      return true;
-    });
-  }, [roles, searchTerm, stageFilter]);
+  const closeFilterDrawer = useCallback(() => {
+    setFilterDrawerOpen(false);
+  }, []);
 
-  const clearFilters = () => {
-    setSearchTerm('');
-    setStageFilter('All');
-  };
+  const openFilterDrawer = useCallback(() => {
+    setDraftFilters(cloneRoleFilters(appliedFilters));
+    setFilterDrawerOpen(true);
+  }, [appliedFilters]);
 
-  const hasActiveFilters =
-    searchTerm.trim().length > 0 || stageFilter !== 'All';
+  const applyDraftFilters = useCallback(() => {
+    setAppliedFilters(cloneRoleFilters(draftFilters));
+    setFilterDrawerOpen(false);
+  }, [draftFilters]);
+
+  const clearDraftFilters = useCallback(() => {
+    setDraftFilters(createEmptyRoleFilters());
+  }, []);
+
+  const hasActiveFilters = appliedFilterCount > 0;
 
   const renderBody = () => {
     if (loading) {
@@ -127,9 +153,11 @@ const PublicRoles = () => {
     return (
       <>
         <p className="mb-4 font-montserrat text-sm text-grayishBlue">
-          Showing {filteredRoles.length}
-          {hasActiveFilters ? ` of ${roles.length}` : ''} open{' '}
-          {filteredRoles.length === 1 ? 'role' : 'roles'}
+          Showing {filteredRoles.length}{' '}
+          {filteredRoles.length === 1 ? 'opportunity' : 'opportunities'} across{' '}
+          {filteredProductionCount}{' '}
+          {filteredProductionCount === 1 ? 'production' : 'productions'} in
+          Chicago, IL
         </p>
         <div data-testid="public-roles-list">
           {filteredRoles.map((role, index) => (
@@ -177,10 +205,20 @@ const PublicRoles = () => {
               system, otherwise filtering is meaningless. */}
           {!loading && roles.length > 0 && (
             <PublicRolesFilters
-              onSearchChange={setSearchTerm}
-              onStageFilterChange={setStageFilter}
-              searchTerm={searchTerm}
-              stageFilter={stageFilter}
+              appliedCount={appliedFilterCount}
+              onOpen={openFilterDrawer}
+              triggerRef={filterTriggerRef}
+            />
+          )}
+
+          {!loading && roles.length > 0 && (
+            <RolesFilterDrawer
+              draft={draftFilters}
+              onApply={applyDraftFilters}
+              onChange={setDraftFilters}
+              onClear={clearDraftFilters}
+              onClose={closeFilterDrawer}
+              open={filterDrawerOpen}
             />
           )}
 

--- a/src/test/PublicRoles.test.tsx
+++ b/src/test/PublicRoles.test.tsx
@@ -72,6 +72,20 @@ describe('PublicRoles route', () => {
     expect(screen.getByText('Stage Manager')).toBeInTheDocument();
     expect(screen.getByText('Hamlet')).toBeInTheDocument();
     expect(screen.getByText('Macbeth')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Showing 2 opportunities across 2 productions in Chicago, IL'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /filter roles, 0 applied/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/Search roles by name or production/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/Filter by stage type/i)
+    ).not.toBeInTheDocument();
     // Theatre attribution is intentionally absent on the unauth surface;
     // see the comment in PublicShows/api.ts about the email leak.
     expect(screen.queryByText('Steppenwolf')).not.toBeInTheDocument();
@@ -124,8 +138,15 @@ describe('PublicRoles route', () => {
     // Wait for initial render of the list before filtering.
     await screen.findByText('Lead Actor');
 
-    const search = screen.getByLabelText(/Search roles by name or production/i);
-    fireEvent.change(search, { target: { value: 'zzznoresults' } });
+    fireEvent.click(
+      screen.getByRole('button', { name: /filter roles, 0 applied/i })
+    );
+
+    await screen.findByRole('dialog', { name: /filter roles/i });
+    fireEvent.change(screen.getByLabelText(/Minimum/i), {
+      target: { value: '9999' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: /apply filters/i }));
 
     expect(
       await screen.findByTestId('public-roles-no-results')
@@ -143,6 +164,9 @@ describe('PublicRoles route', () => {
     await waitFor(() => {
       expect(screen.getByText('Lead Actor')).toBeInTheDocument();
     });
+    expect(
+      screen.getByRole('button', { name: /filter roles, 0 applied/i })
+    ).toBeInTheDocument();
   });
 
   it('top sign-up CTA links to /sign-up and /get-involved when roles exist', async () => {
@@ -168,19 +192,34 @@ describe('PublicRoles route', () => {
     expect(howItWorksLinks[0]).toHaveAttribute('href', '/get-involved');
   });
 
-  it('filters by stage type', async () => {
+  it('filters by role type from the drawer', async () => {
     mockFetch.mockResolvedValueOnce(sampleRoles as never);
 
     renderRoute();
 
     await screen.findByText('Lead Actor');
 
-    const stageSelect = screen.getByLabelText(/Filter by stage type/i);
-    fireEvent.change(stageSelect, { target: { value: 'Off-Stage' } });
+    fireEvent.click(
+      screen.getByRole('button', { name: /filter roles, 0 applied/i })
+    );
+
+    await screen.findByRole('dialog', { name: /filter roles/i });
+    fireEvent.change(screen.getByLabelText(/Filter by role type/i), {
+      target: { value: 'Off-Stage' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: /apply filters/i }));
 
     await waitFor(() => {
       expect(screen.queryByText('Lead Actor')).not.toBeInTheDocument();
     });
     expect(screen.getByText('Stage Manager')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Showing 1 opportunity across 1 production in Chicago, IL'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /filter roles, 1 applied/i })
+    ).toBeInTheDocument();
   });
 });

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -51,6 +51,7 @@ export default {
         yellow: '#EFC93D',
         yoda: '#B8D8C7',
         evergreen: '#4A725D',
+        filterCream: '#FBF6EC',
         gold: '#D3991C'
       },
       keyframes: {


### PR DESCRIPTION
Summary:
- Add public /roles filter drawer with role type, demographics, union, requirements, and pay filters.
- Reuse the drawer as the mobile full-screen overlay takeover.
- Update public roles tests and filter predicate coverage.

Validation:
- npm test
- npm run build
- Playwright MCP desktop/mobile smoke validation on /roles

QA notes:
- Prior validation found the visible checkbox box measures 32px while DEV-500 says 40px.
- Prior validation found the mobile overlay title renders as Filter Roles while DEV-500 says FILTER MENU.