### PR TITLE
Fix threads/messages Firestore rules checking fields the app never writes (staging)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -176,19 +176,47 @@ service cloud.firestore {
     }
 
     // Threads collection
+    // Thread docs reference their two sides via theater_account_id /
+    // talent_account_id — Firestore DocumentReferences into `accounts`,
+    // not auth UIDs directly (see Messages/api.ts createMessageThread).
+    // Resolve each reference to its account's `uid` field to check
+    // participation. (Previously checked `participants`/`created_by`
+    // fields that the app never wrote, so every update after the initial
+    // create was silently denied.)
+    function isThreadParticipant(threadData) {
+      return isAuthenticated() && (
+        (threadData.theater_account_id != null &&
+         get(threadData.theater_account_id).data.uid == request.auth.uid) ||
+        (threadData.talent_account_id != null &&
+         get(threadData.talent_account_id).data.uid == request.auth.uid)
+      );
+    }
+
     match /threads/{threadId} {
-      allow read, write: if isAuthenticated() &&
-        (resource == null ||
-         request.auth.uid in resource.data.participants ||
-         request.auth.uid == resource.data.created_by);
+      allow read, update, delete: if isThreadParticipant(resource.data);
+      allow create: if isThreadParticipant(request.resource.data);
     }
 
     // Messages collection
+    // Message docs reference sender/recipient via sender_id / recipient_id
+    // — Firestore DocumentReferences into `accounts`, not auth UIDs
+    // directly (see Messages/api.ts createMessageThread). Resolve each
+    // reference the same way as threads. (Previously checked `sender_id
+    // == auth.uid` and a `recipients` array that never matched the actual
+    // reference-typed `sender_id` / singular `recipient_id` fields, so
+    // every update after the initial create was silently denied.)
+    function isMessageParticipant(messageData) {
+      return isAuthenticated() && (
+        (messageData.sender_id != null &&
+         get(messageData.sender_id).data.uid == request.auth.uid) ||
+        (messageData.recipient_id != null &&
+         get(messageData.recipient_id).data.uid == request.auth.uid)
+      );
+    }
+
     match /messages/{messageId} {
-      allow read, write: if isAuthenticated() &&
-        (resource == null ||
-         request.auth.uid == resource.data.sender_id ||
-         request.auth.uid in resource.data.recipients);
+      allow read, update, delete: if isMessageParticipant(resource.data);
+      allow create: if isMessageParticipant(request.resource.data);
     }
 
     // Mail collection

--- a/src/test/firestore.rules.test.ts
+++ b/src/test/firestore.rules.test.ts
@@ -289,6 +289,166 @@ describe('events collection (regression — was already public)', () => {
   });
 });
 
+describe('threads collection', () => {
+  // Thread docs store theater_account_id / talent_account_id as
+  // DocumentReferences into `accounts` (see Messages/api.ts
+  // createMessageThread) — account doc IDs are auto-generated and
+  // distinct from the owning user's auth uid, so these seeds mirror that
+  // by giving the account doc a different ID than its `uid` field.
+  const seedAccountsAndThread = () =>
+    seed(async (db) => {
+      await setDoc(doc(db, 'accounts', 'theater-acct-doc'), {
+        uid: 'theater-auth-uid',
+        type: 'company'
+      });
+      await setDoc(doc(db, 'accounts', 'talent-acct-doc'), {
+        uid: 'talent-auth-uid',
+        type: 'individual'
+      });
+      await setDoc(doc(db, 'threads', 'thread-1'), {
+        theater_account_id: doc(db, 'accounts', 'theater-acct-doc'),
+        talent_account_id: doc(db, 'accounts', 'talent-acct-doc'),
+        theater_status: 'new',
+        talent_status: 'new',
+        last_message: { content: 'hello' }
+      });
+    });
+
+  it('theater participant CAN update an existing thread (regression for the participants/created_by bug)', async () => {
+    await seedAccountsAndThread();
+
+    await assertSucceeds(
+      updateDoc(doc(asUser('theater-auth-uid'), 'threads', 'thread-1'), {
+        last_message: { content: 'updated' }
+      })
+    );
+  });
+
+  it('talent participant CAN update an existing thread', async () => {
+    await seedAccountsAndThread();
+
+    await assertSucceeds(
+      updateDoc(doc(asUser('talent-auth-uid'), 'threads', 'thread-1'), {
+        talent_status: 'read'
+      })
+    );
+  });
+
+  it('non-participant CANNOT read or update a thread', async () => {
+    await seedAccountsAndThread();
+
+    await assertFails(getDoc(doc(asUser('attacker'), 'threads', 'thread-1')));
+    await assertFails(
+      updateDoc(doc(asUser('attacker'), 'threads', 'thread-1'), {
+        last_message: { content: 'hacked' }
+      })
+    );
+  });
+
+  it('a participant CAN create a new thread referencing both accounts', async () => {
+    await seed(async (db) => {
+      await setDoc(doc(db, 'accounts', 'theater-acct-doc'), {
+        uid: 'theater-auth-uid',
+        type: 'company'
+      });
+      await setDoc(doc(db, 'accounts', 'talent-acct-doc'), {
+        uid: 'talent-auth-uid',
+        type: 'individual'
+      });
+    });
+
+    const db = asUser('theater-auth-uid');
+    await assertSucceeds(
+      setDoc(doc(db, 'threads', 'thread-new'), {
+        theater_account_id: doc(db, 'accounts', 'theater-acct-doc'),
+        talent_account_id: doc(db, 'accounts', 'talent-acct-doc'),
+        theater_status: 'new',
+        talent_status: 'new'
+      })
+    );
+  });
+
+  it('a non-participant CANNOT create a thread for two other accounts', async () => {
+    await seed(async (db) => {
+      await setDoc(doc(db, 'accounts', 'theater-acct-doc'), {
+        uid: 'theater-auth-uid',
+        type: 'company'
+      });
+      await setDoc(doc(db, 'accounts', 'talent-acct-doc'), {
+        uid: 'talent-auth-uid',
+        type: 'individual'
+      });
+    });
+
+    const db = asUser('attacker');
+    await assertFails(
+      setDoc(doc(db, 'threads', 'thread-evil'), {
+        theater_account_id: doc(db, 'accounts', 'theater-acct-doc'),
+        talent_account_id: doc(db, 'accounts', 'talent-acct-doc')
+      })
+    );
+  });
+});
+
+describe('messages collection', () => {
+  // Message docs store sender_id / recipient_id as DocumentReferences
+  // into `accounts` (see Messages/api.ts createMessageThread), same
+  // account-doc-id-vs-auth-uid distinction as threads above.
+  const seedAccountsAndMessage = () =>
+    seed(async (db) => {
+      await setDoc(doc(db, 'accounts', 'sender-acct-doc'), {
+        uid: 'sender-auth-uid',
+        type: 'company'
+      });
+      await setDoc(doc(db, 'accounts', 'recipient-acct-doc'), {
+        uid: 'recipient-auth-uid',
+        type: 'individual'
+      });
+      await setDoc(doc(db, 'messages', 'message-1'), {
+        sender_id: doc(db, 'accounts', 'sender-acct-doc'),
+        recipient_id: doc(db, 'accounts', 'recipient-acct-doc'),
+        content: 'hi',
+        status: 'new'
+      });
+    });
+
+  it('sender CAN update an existing message (e.g. backfilling thread_id — regression for the sender_id/recipients bug)', async () => {
+    await seedAccountsAndMessage();
+
+    await assertSucceeds(
+      updateDoc(doc(asUser('sender-auth-uid'), 'messages', 'message-1'), {
+        thread_id: 'thread-1'
+      })
+    );
+  });
+
+  it('recipient CAN read and update an existing message', async () => {
+    await seedAccountsAndMessage();
+
+    await assertSucceeds(
+      getDoc(doc(asUser('recipient-auth-uid'), 'messages', 'message-1'))
+    );
+    await assertSucceeds(
+      updateDoc(doc(asUser('recipient-auth-uid'), 'messages', 'message-1'), {
+        status: 'read'
+      })
+    );
+  });
+
+  it('non-participant CANNOT read or update a message', async () => {
+    await seedAccountsAndMessage();
+
+    await assertFails(
+      getDoc(doc(asUser('attacker'), 'messages', 'message-1'))
+    );
+    await assertFails(
+      updateDoc(doc(asUser('attacker'), 'messages', 'message-1'), {
+        status: 'read'
+      })
+    );
+  });
+});
+
 describe('default deny', () => {
   it('unauthenticated user CANNOT read an unmapped collection', async () => {
     await seed(async (db) => {


### PR DESCRIPTION
Cherry-pick of the fix already merged to master in #321, onto \`staging\` (this repo's branches diverge — master was several commits behind staging, so the same fix needed a separate PR here).

## Summary
- \`threads\`/\`messages\` security rules checked \`participants\`/\`created_by\` and \`sender_id == auth.uid\`/\`recipients\`, but \`Messages/api.ts\` actually stores \`theater_account_id\`/\`talent_account_id\` and \`sender_id\`/\`recipient_id\` as DocumentReferences into \`accounts\` — none of the fields the rules checked ever existed on these docs.
- The initial create always passed (\`resource == null\` bypasses the check), but every subsequent update was silently denied — including the \`thread_id\` backfill that runs on every message send. This has been live on staging, untested, affecting the messaging feature.
- Fix resolves each account reference to its \`uid\` field via \`get()\`.
- Already deployed to \`chicago-artist-guide-dev\` (staging's Firebase backend) directly for immediate effect; this PR brings the source of truth in the repo in sync with that deploy.

## Test plan
- [x] 26/26 rules tests passing (\`npm run test:rules\`) on top of staging's current code.
- [x] Clean cherry-pick, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)