### PR TITLE
Track Firestore composite indexes in the repo

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,7 @@
 {
   "firestore": {
-    "rules": "firestore.rules"
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
   },
   "emulators": {
     "firestore": {

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,49 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "recipient_id", "order": "ASCENDING" },
+        { "fieldPath": "thread_id", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "recipient_id", "order": "ASCENDING" },
+        { "fieldPath": "thread_id", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "sender_id", "order": "ASCENDING" },
+        { "fieldPath": "thread_id", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "sender_id", "order": "ASCENDING" },
+        { "fieldPath": "thread_id", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "productions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "production_name", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
## Summary
`firestore.indexes.json` was never version-controlled (same gap that let the threads/messages rules bug — see #321 — ship untested). Adds it, referenced from `firebase.json`.

Contains:
- The 4 indexes already live on both dev and prod (`messages`: sender_id/recipient_id + thread_id + timestamp, asc/desc) — tracking what's already deployed, no functional change.
- **New**: `productions` (status + production_name) — the index `/shows` (`src/routes/PublicShows.tsx`) has needed since it shipped in May 2025. That query has been silently failing in production this entire time — the error gets caught and swallowed into a false "No active shows found" empty state. Confirmed via console: `FirebaseError: The query requires an index`. Dev already has this index (created ad hoc via the Firebase Console during original development); prod never got it since index creation was never part of any deploy pipeline.

## Test plan
- [x] `npm run build` passes.
- [ ] Deploy `firestore:indexes` to dev (no-op, already has all 5) and prod (creates the missing one) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)