### PR TITLE
Add admin-facing indicator for whether a company's shows are actually live

### DIFF
--- a/src/components/Admin/Companies/CompanyCard.tsx
+++ b/src/components/Admin/Companies/CompanyCard.tsx
@@ -157,10 +157,20 @@ const CompanyCard: React.FC<React.PropsWithChildren<CompanyCardProps>> = ({
         ) : (
           <Badge $variant="warning">Incomplete</Badge>
         )}
+        {(company.productions_count || 0) > 0 &&
+          !(company.live_productions_count || 0) && (
+            <Badge $variant="warning" title="No shows visible on the public site right now">
+              Nothing public
+            </Badge>
+          )}
       </div>
 
       <Stats>
-        <span>{company.productions_count || 0} productions</span>
+        <span>
+          {company.productions_count
+            ? `${company.live_productions_count || 0} of ${company.productions_count} live`
+            : '0 productions'}
+        </span>
         {company.primary_contact && (
           <span>Contact: {company.primary_contact}</span>
         )}

--- a/src/components/Admin/Companies/CompanyDetailsModal.tsx
+++ b/src/components/Admin/Companies/CompanyDetailsModal.tsx
@@ -299,6 +299,29 @@ const CompanyDetailsModal: React.FC<
             <InfoGrid>
               <Label>Productions:</Label>
               <Value>{company.productions_count || 0} productions</Value>
+
+              <Label>Live to the public:</Label>
+              <Value
+                style={{
+                  color:
+                    (company.productions_count || 0) > 0 &&
+                    !(company.live_productions_count || 0)
+                      ? colors.salmon
+                      : undefined,
+                  fontWeight:
+                    (company.productions_count || 0) > 0 &&
+                    !(company.live_productions_count || 0)
+                      ? 700
+                      : undefined
+                }}
+              >
+                {company.live_productions_count || 0} of{' '}
+                {company.productions_count || 0} shows visible on /roles or
+                /shows right now
+                {(company.productions_count || 0) > 0 &&
+                  !(company.live_productions_count || 0) &&
+                  ' — nothing is public. Check each show’s Status field (must be Hiring, Casting, or Pre-Production) and that at least one role is added and marked Open.'}
+              </Value>
             </InfoGrid>
           </div>
 

--- a/src/hooks/useCompanies.test.ts
+++ b/src/hooks/useCompanies.test.ts
@@ -1,0 +1,59 @@
+import { isProductionLive } from './useCompanies';
+
+describe('isProductionLive', () => {
+  it('is false when status is not active (e.g. In Production)', () => {
+    expect(
+      isProductionLive({
+        status: 'In Production',
+        roles: [{ role_status: 'Open' }]
+      })
+    ).toBe(false);
+  });
+
+  it('is false when status is missing', () => {
+    expect(isProductionLive({ roles: [{ role_status: 'Open' }] })).toBe(false);
+  });
+
+  it('is false when status is active but roles is empty (the Danztheatre case)', () => {
+    expect(isProductionLive({ status: 'Hiring', roles: [] })).toBe(false);
+  });
+
+  it('is false when status is active but roles is missing entirely', () => {
+    expect(isProductionLive({ status: 'Hiring' })).toBe(false);
+  });
+
+  it('is false when status is active but every role is Closed', () => {
+    expect(
+      isProductionLive({
+        status: 'Hiring',
+        roles: [{ role_status: 'Closed' }, { role_status: 'Closed' }]
+      })
+    ).toBe(false);
+  });
+
+  it('is true when status is active and at least one role is Open', () => {
+    expect(
+      isProductionLive({
+        status: 'Hiring',
+        roles: [{ role_status: 'Closed' }, { role_status: 'Open' }]
+      })
+    ).toBe(true);
+  });
+
+  it('is true when status is active and a role has no role_status set (treated as open)', () => {
+    expect(
+      isProductionLive({
+        status: 'Casting',
+        roles: [{}]
+      })
+    ).toBe(true);
+  });
+
+  it('is true for each of the three active statuses', () => {
+    for (const status of ['Hiring', 'Casting', 'Pre-Production']) {
+      expect(isProductionLive({ status, roles: [{ role_status: 'Open' }] })).toBe(
+        true
+      );
+    }
+  });
+});

--- a/src/hooks/useCompanies.ts
+++ b/src/hooks/useCompanies.ts
@@ -8,6 +8,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { collection, getDocs, query, where } from 'firebase/firestore';
 import { useFirebaseContext } from '../context/FirebaseContext';
+import { ACTIVE_PRODUCTION_STATUSES } from '../utils/lookups';
 
 /**
  * Company data structure combining account + profile
@@ -37,6 +38,11 @@ export interface CompanyData {
 
   // Counts
   productions_count?: number;
+  // Productions that are actually visible on the public /roles or /shows
+  // pages right now: active status (Hiring/Casting/Pre-Production) AND at
+  // least one role marked Open. Mirrors fetchPublicOpenRoles in
+  // src/components/PublicShows/api.ts -- keep these in sync.
+  live_productions_count?: number;
 }
 
 /**
@@ -175,6 +181,27 @@ function applySorting(
 }
 
 /**
+ * Whether a production is currently visible on the public /roles or /shows
+ * pages: active status AND at least one role explicitly Open (or with no
+ * role_status set, which the public pages treat as open by convention).
+ * Mirrors fetchPublicOpenRoles in src/components/PublicShows/api.ts.
+ */
+export function isProductionLive(production: any): boolean {
+  if (!ACTIVE_PRODUCTION_STATUSES.includes(production.status)) {
+    return false;
+  }
+
+  const roles = Array.isArray(production.roles) ? production.roles : [];
+  return roles.some(
+    (role: any) =>
+      role &&
+      typeof role === 'object' &&
+      !Array.isArray(role) &&
+      (role.role_status === undefined || role.role_status === 'Open')
+  );
+}
+
+/**
  * useCompanies Hook
  */
 export function useCompanies(
@@ -256,13 +283,20 @@ export function useCompanies(
       const productionsRef = collection(firebaseFirestore, 'productions');
       const productionsSnapshot = await getDocs(productionsRef);
 
-      // Count productions per account
+      // Count productions per account, and how many of those are actually
+      // live to the public right now.
       const productionsCount = new Map<string, number>();
+      const liveProductionsCount = new Map<string, number>();
       productionsSnapshot.forEach((doc) => {
         const prod = doc.data();
         if (prod.account_id) {
           const count = productionsCount.get(prod.account_id) || 0;
           productionsCount.set(prod.account_id, count + 1);
+
+          if (isProductionLive(prod)) {
+            const liveCount = liveProductionsCount.get(prod.account_id) || 0;
+            liveProductionsCount.set(prod.account_id, liveCount + 1);
+          }
         }
       });
 
@@ -296,7 +330,8 @@ export function useCompanies(
           profile_exists: !!profile,
 
           // Counts
-          productions_count: productionsCount.get(doc.id) || 0
+          productions_count: productionsCount.get(doc.id) || 0,
+          live_productions_count: liveProductionsCount.get(doc.id) || 0
         });
       });
 


### PR DESCRIPTION
## Summary
Anna (Executive Director) had no way to check whether a theatre company's posting is actually visible on the public site without a developer looking at the raw production record — this is what surfaced when Chicago Danztheatre Ensemble's casting call wasn't showing up (turned out to be zero roles added, but there was no way for her to see that herself).

`useCompanies.ts` already fetches every production into memory to compute `productions_count`; this adds `live_productions_count` alongside it using the exact same visibility rule as the public `/roles` page (`fetchPublicOpenRoles`): active status (Hiring/Casting/Pre-Production) AND at least one role marked Open.

Surfaced in two places, kept intentionally light-touch:
- A "Nothing public" warning badge on the company grid card — visible while scanning the list, no click needed.
- A full "X of Y shows visible on /roles or /shows right now" line in the company details modal, with plain-language guidance (check Status field, check role is Open) when nothing's live.

## Test plan
- [x] 8 new unit tests for the visibility logic (`isProductionLive`), covering all three active statuses, missing/empty roles, all-closed roles, and the exact Danztheatre case (active status + zero roles).
- [x] `npm run test` — all passing except the one pre-existing, unrelated `EditPersonalDetails.test.tsx` failure.
- [x] `npm run lint` — clean.
- [x] `npm run build` — succeeds.

Requesting review before merge to master — deploying to staging now for a visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)