### PR TITLE
Add admin show/hide toggle for individual productions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -153,11 +153,19 @@ service cloud.firestore {
     // - Public read access (productions are publicly-advertised auditions; powers the
     //   /roles unauth marketing browse — DEV-496)
     // - Companies can create/update/delete their own productions
+    // - Admins can flip admin_hidden only (public-visibility toggle) on any
+    //   production, without gaining general edit rights over another
+    //   company's show content
     match /productions/{productionId} {
       allow read: if true;
       allow create: if isAuthenticated() &&
         request.resource.data.account_id == request.auth.uid;
-      allow update, delete: if isAuthenticated() &&
+      allow update: if isAuthenticated() && (
+        resource.data.account_id == request.auth.uid ||
+        (isAdminOrHigher() &&
+         request.resource.data.diff(resource.data).affectedKeys().hasOnly(['admin_hidden']))
+      );
+      allow delete: if isAuthenticated() &&
         resource.data.account_id == request.auth.uid;
     }
 
@@ -306,7 +314,8 @@ service cloud.firestore {
           'company_view', 'company_edit', 'company_create', 'company_approve', 'company_reject',
           'opening_view', 'opening_edit', 'opening_moderate', 'opening_create', 'opening_delete',
           'event_view', 'event_create', 'event_edit', 'event_delete', 'event_publish',
-          'role_change', 'delete', 'export', 'profile_view', 'account_create'
+          'role_change', 'delete', 'export', 'profile_view', 'account_create',
+          'production_visibility_change'
         ] &&
         request.resource.data.target_type in ['user', 'company', 'production', 'role', 'opening', 'event', 'match', 'theatre_request', 'account', 'profile', 'system'];
       allow update: if false;

--- a/src/components/Admin/Companies/CompanyDetailsModal.tsx
+++ b/src/components/Admin/Companies/CompanyDetailsModal.tsx
@@ -4,7 +4,7 @@
  * Shows full company account and profile data with option to edit.
  */
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
@@ -12,12 +12,20 @@ import {
   faEdit,
   faExternalLinkAlt,
   faBan,
-  faCheckCircle
+  faCheckCircle,
+  faEye,
+  faEyeSlash
 } from '@fortawesome/free-solid-svg-icons';
 import { colors } from '../../../theme/styleVars';
-import { CompanyData } from '../../../hooks/useCompanies';
+import { CompanyData, isProductionLive } from '../../../hooks/useCompanies';
 import { useAdminAuth } from '../../../hooks/useAdminAuth';
 import { useAdminActions } from '../../../hooks/useAdminActions';
+import { useFirebaseContext } from '../../../context/FirebaseContext';
+import { Production } from '../../Profile/Company/types';
+import {
+  getProductionsForAccount,
+  setProductionAdminHidden
+} from './api';
 import AdminButton from '../shared/AdminButton';
 
 interface CompanyDetailsModalProps {
@@ -129,6 +137,53 @@ const StatusBadge = styled.span<{ $status: 'active' | 'disabled' }>`
       : `background: ${colors.salmon}20; color: ${colors.salmon};`}
 `;
 
+const ProductionRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid ${colors.bodyBg};
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const ProductionName = styled.div`
+  font-family: 'Open Sans', sans-serif;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: ${colors.slate};
+`;
+
+const ProductionMeta = styled.div`
+  font-family: 'Open Sans', sans-serif;
+  font-size: 0.75rem;
+  color: ${colors.grayishBlue};
+`;
+
+const VisibilityToggle = styled.button<{ $hidden: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 4px;
+  border: 1px solid ${(props) => (props.$hidden ? colors.salmon : colors.mint)};
+  background: ${(props) =>
+    props.$hidden ? `${colors.salmon}10` : `${colors.mint}10`};
+  color: ${(props) => (props.$hidden ? colors.salmon : colors.mint)};
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
 const Footer = styled.div`
   display: flex;
   align-items: center;
@@ -157,7 +212,74 @@ const CompanyDetailsModal: React.FC<
 > = ({ company, onClose, onEdit }) => {
   const { hasPermission } = useAdminAuth();
   const { logAction } = useAdminActions();
+  const { firebaseFirestore } = useFirebaseContext();
   const hasLoggedViewRef = useRef(false);
+  const [productions, setProductions] = useState<Production[]>([]);
+  const [productionsLoading, setProductionsLoading] = useState(true);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+
+  // Load this company's shows so an admin can see/toggle public visibility
+  // per-show, not just the aggregate count.
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadProductions = async () => {
+      setProductionsLoading(true);
+      const results = await getProductionsForAccount(
+        firebaseFirestore,
+        company.accountId
+      );
+      if (isMounted) {
+        setProductions(
+          [...results].sort((a, b) =>
+            (a.production_name || '').localeCompare(b.production_name || '')
+          )
+        );
+        setProductionsLoading(false);
+      }
+    };
+
+    loadProductions();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [firebaseFirestore, company.accountId]);
+
+  const handleToggleVisibility = async (production: Production) => {
+    const nextHidden = !production.admin_hidden;
+    setTogglingId(production.production_id);
+
+    try {
+      await setProductionAdminHidden(
+        firebaseFirestore,
+        production.production_id,
+        nextHidden
+      );
+
+      setProductions((prev) =>
+        prev.map((p) =>
+          p.production_id === production.production_id
+            ? { ...p, admin_hidden: nextHidden }
+            : p
+        )
+      );
+
+      logAction({
+        action_type: 'production_visibility_change',
+        target_type: 'production',
+        target_id: production.production_id,
+        target_name: production.production_name,
+        changes: {
+          before: { admin_hidden: !!production.admin_hidden },
+          after: { admin_hidden: nextHidden },
+          fields_changed: ['admin_hidden']
+        }
+      });
+    } finally {
+      setTogglingId(null);
+    }
+  };
 
   // Log view action - only once per modal open
   useEffect(() => {
@@ -324,6 +446,52 @@ const CompanyDetailsModal: React.FC<
               </Value>
             </InfoGrid>
           </div>
+
+          {/* Shows */}
+          {productions.length > 0 && (
+            <div className="mb-[2rem] last:mb-0">
+              <SectionTitle>Shows</SectionTitle>
+              {productionsLoading ? (
+                <Value>Loading…</Value>
+              ) : (
+                productions.map((production) => {
+                  const live = isProductionLive(production);
+                  return (
+                    <ProductionRow key={production.production_id}>
+                      <div>
+                        <ProductionName>
+                          {production.production_name || '(Untitled)'}
+                        </ProductionName>
+                        <ProductionMeta>
+                          Status: {production.status || 'Not set'} ·{' '}
+                          {live ? 'Visible to the public' : 'Not visible'}
+                        </ProductionMeta>
+                      </div>
+                      {canEdit && (
+                        <VisibilityToggle
+                          $hidden={!!production.admin_hidden}
+                          disabled={togglingId === production.production_id}
+                          onClick={() => handleToggleVisibility(production)}
+                          title={
+                            production.admin_hidden
+                              ? 'Hidden by an admin — click to unhide'
+                              : 'Click to hide this show from /roles and /shows, regardless of its status'
+                          }
+                        >
+                          <FontAwesomeIcon
+                            icon={production.admin_hidden ? faEyeSlash : faEye}
+                          />
+                          {production.admin_hidden
+                            ? 'Hidden by admin'
+                            : 'Hide from public'}
+                        </VisibilityToggle>
+                      )}
+                    </ProductionRow>
+                  );
+                })
+              )}
+            </div>
+          )}
 
           {/* Description */}
           {company.description && (

--- a/src/components/Admin/Companies/api.ts
+++ b/src/components/Admin/Companies/api.ts
@@ -1,0 +1,58 @@
+/**
+ * Admin Companies API — production-level admin actions.
+ */
+
+import {
+  collection,
+  doc,
+  Firestore,
+  getDocs,
+  query,
+  updateDoc,
+  where
+} from 'firebase/firestore';
+import { Production } from '../../Profile/Company/types';
+
+/**
+ * All productions owned by a company account, newest first isn't tracked
+ * (productions don't carry a reliable created_at), so this returns them in
+ * whatever order Firestore hands back — callers that need a stable order
+ * should sort by production_name.
+ */
+export const getProductionsForAccount = async (
+  firebaseStore: Firestore,
+  accountId: string
+): Promise<Production[]> => {
+  if (!accountId) {
+    return [];
+  }
+
+  const productionsRef = collection(firebaseStore, 'productions');
+  const productionsQuery = query(
+    productionsRef,
+    where('account_id', '==', accountId)
+  );
+  const snapshot = await getDocs(productionsQuery);
+
+  return snapshot.docs.map((productionDoc) => {
+    const data = productionDoc.data() as Production;
+    return {
+      ...data,
+      production_id: data.production_id || productionDoc.id
+    };
+  });
+};
+
+/**
+ * Admin-only visibility toggle. Firestore rules restrict this update to
+ * exactly the admin_hidden field (see firestore.rules) — it cannot be used
+ * to edit any other part of a production the admin doesn't own.
+ */
+export const setProductionAdminHidden = async (
+  firebaseStore: Firestore,
+  productionId: string,
+  hidden: boolean
+): Promise<void> => {
+  const productionRef = doc(firebaseStore, 'productions', productionId);
+  await updateDoc(productionRef, { admin_hidden: hidden });
+};

--- a/src/components/Profile/Company/types.ts
+++ b/src/components/Profile/Company/types.ts
@@ -78,6 +78,11 @@ export type Production = {
   contact_person_email_audition?: string;
   materials_to_prepare_audition?: string;
   additional_notes_audition?: string;
+  // Admin-only visibility override (see firestore.rules) — hides the
+  // production from the public /roles and /shows pages regardless of
+  // status. Not editable by the owning company; toggled from the Admin
+  // Companies panel.
+  admin_hidden?: boolean;
 };
 
 export type Role = {

--- a/src/components/PublicShows/api.ts
+++ b/src/components/PublicShows/api.ts
@@ -52,7 +52,8 @@ export const fetchPublicOpenRoles = async (
         typeof p.production_name === 'string' &&
         p.production_name.length > 0 &&
         typeof p.account_id === 'string' &&
-        p.account_id.length > 0
+        p.account_id.length > 0 &&
+        !p.admin_hidden
     );
 
   const items: PublicRoleListItem[] = [];

--- a/src/hooks/useAdminActions.ts
+++ b/src/hooks/useAdminActions.ts
@@ -33,7 +33,8 @@ export type AdminActionType =
   | 'event_create'
   | 'event_edit'
   | 'event_delete'
-  | 'event_publish';
+  | 'event_publish'
+  | 'production_visibility_change';
 
 /**
  * Admin action target types
@@ -44,6 +45,7 @@ export type AdminActionTargetType =
   | 'theatre_request'
   | 'opening'
   | 'event'
+  | 'production'
   | 'system';
 
 /**

--- a/src/hooks/useCompanies.test.ts
+++ b/src/hooks/useCompanies.test.ts
@@ -56,4 +56,24 @@ describe('isProductionLive', () => {
       );
     }
   });
+
+  it('is false when admin_hidden is true, even with active status and an open role', () => {
+    expect(
+      isProductionLive({
+        status: 'Hiring',
+        roles: [{ role_status: 'Open' }],
+        admin_hidden: true
+      })
+    ).toBe(false);
+  });
+
+  it('is true when admin_hidden is explicitly false', () => {
+    expect(
+      isProductionLive({
+        status: 'Hiring',
+        roles: [{ role_status: 'Open' }],
+        admin_hidden: false
+      })
+    ).toBe(true);
+  });
 });

--- a/src/hooks/useCompanies.ts
+++ b/src/hooks/useCompanies.ts
@@ -182,11 +182,15 @@ function applySorting(
 
 /**
  * Whether a production is currently visible on the public /roles or /shows
- * pages: active status AND at least one role explicitly Open (or with no
- * role_status set, which the public pages treat as open by convention).
- * Mirrors fetchPublicOpenRoles in src/components/PublicShows/api.ts.
+ * pages: not admin-hidden, active status, AND at least one role explicitly
+ * Open (or with no role_status set, which the public pages treat as open by
+ * convention). Mirrors fetchPublicOpenRoles in src/components/PublicShows/api.ts.
  */
 export function isProductionLive(production: any): boolean {
+  if (production.admin_hidden) {
+    return false;
+  }
+
   if (!ACTIVE_PRODUCTION_STATUSES.includes(production.status)) {
     return false;
   }

--- a/src/routes/PublicShows.tsx
+++ b/src/routes/PublicShows.tsx
@@ -72,14 +72,15 @@ const PublicShows = () => {
 
         if (!isMounted) return;
 
-        // Filter out invalid productions from the count
+        // Filter out invalid or admin-hidden productions from the count
         const validProductions = countSnapshot.docs.filter((doc) => {
           const data = doc.data();
           return (
             data.production_name &&
             data.account_id &&
             typeof data.production_name === 'string' &&
-            typeof data.account_id === 'string'
+            typeof data.account_id === 'string' &&
+            !data.admin_hidden
           );
         });
 
@@ -150,12 +151,13 @@ const PublicShows = () => {
             };
           })
           .filter((production) => {
-            // Filter out productions without required fields
+            // Filter out productions without required fields, or hidden by an admin
             return (
               production.production_name &&
               production.account_id &&
               typeof production.production_name === 'string' &&
-              typeof production.account_id === 'string'
+              typeof production.account_id === 'string' &&
+              !production.admin_hidden
             );
           });
 

--- a/src/test/firestore.rules.test.ts
+++ b/src/test/firestore.rules.test.ts
@@ -209,6 +209,116 @@ describe('productions collection', () => {
       })
     );
   });
+
+  // Admin-only visibility toggle (production_visibility_change)
+  const seedAdmin = (uid: string, role = 'admin') =>
+    seed(async (db) => {
+      await setDoc(doc(db, 'admin_users', uid), { role });
+    });
+
+  it('admin CAN toggle admin_hidden on a production they do not own', async () => {
+    await seedAdmin('admin-1');
+    await seed(async (db) => {
+      await setDoc(doc(db, 'productions', 'prod-1'), {
+        production_id: 'prod-1',
+        account_id: 'company-1',
+        production_name: 'Hamlet'
+      });
+    });
+
+    await assertSucceeds(
+      updateDoc(doc(asUser('admin-1'), 'productions', 'prod-1'), {
+        admin_hidden: true
+      })
+    );
+  });
+
+  it('admin CANNOT change any other field on a production they do not own', async () => {
+    await seedAdmin('admin-1');
+    await seed(async (db) => {
+      await setDoc(doc(db, 'productions', 'prod-1'), {
+        production_id: 'prod-1',
+        account_id: 'company-1',
+        production_name: 'Hamlet'
+      });
+    });
+
+    await assertFails(
+      updateDoc(doc(asUser('admin-1'), 'productions', 'prod-1'), {
+        production_name: 'Hacked by admin'
+      })
+    );
+  });
+
+  it('admin CANNOT bundle admin_hidden with another field change in one update', async () => {
+    await seedAdmin('admin-1');
+    await seed(async (db) => {
+      await setDoc(doc(db, 'productions', 'prod-1'), {
+        production_id: 'prod-1',
+        account_id: 'company-1',
+        production_name: 'Hamlet'
+      });
+    });
+
+    await assertFails(
+      updateDoc(doc(asUser('admin-1'), 'productions', 'prod-1'), {
+        admin_hidden: true,
+        production_name: 'Hacked by admin'
+      })
+    );
+  });
+
+  it('non-admin CANNOT toggle admin_hidden on a production they do not own', async () => {
+    await seed(async (db) => {
+      await setDoc(doc(db, 'productions', 'prod-1'), {
+        production_id: 'prod-1',
+        account_id: 'company-1',
+        production_name: 'Hamlet'
+      });
+    });
+
+    await assertFails(
+      updateDoc(doc(asUser('attacker'), 'productions', 'prod-1'), {
+        admin_hidden: true
+      })
+    );
+  });
+
+  it('owner CAN still update their own production normally (regression)', async () => {
+    await seed(async (db) => {
+      await setDoc(doc(db, 'productions', 'prod-1'), {
+        production_id: 'prod-1',
+        account_id: 'company-1',
+        production_name: 'Hamlet'
+      });
+    });
+
+    await assertSucceeds(
+      updateDoc(doc(asUser('company-1'), 'productions', 'prod-1'), {
+        production_name: 'Hamlet (Revised)',
+        status: 'Hiring'
+      })
+    );
+  });
+});
+
+describe('admin_actions collection — production_visibility_change', () => {
+  it('admin CAN log a production_visibility_change action', async () => {
+    await seed(async (db) => {
+      await setDoc(doc(db, 'admin_users', 'admin-1'), { role: 'admin' });
+    });
+
+    await assertSucceeds(
+      setDoc(doc(asUser('admin-1'), 'admin_actions', 'action-1'), {
+        admin_uid: 'admin-1',
+        admin_email: 'admin@example.com',
+        action_type: 'production_visibility_change',
+        target_type: 'production',
+        target_id: 'prod-1',
+        timestamp: new Date()
+      })
+    );
+  });
 });
 
 describe('profiles collection (must stay auth-gated)', () => {


### PR DESCRIPTION
## Summary
Follow-up to #326. That PR let Anna *see* whether a company's shows are live; this lets her *fix* it when a show shouldn't be public — an update (hide/unhide), not a delete. Addresses the gap found investigating Chicago Danztheatre Ensemble's posting: there was no way, by UI or by rules, for an admin to manage what's publicly visible for another account's productions.

- `firestore.rules`: scoped admin update on `productions` — `request.resource.data.diff(resource.data).affectedKeys().hasOnly(['admin_hidden'])`, so an admin can only flip visibility, never edit a show's actual content (name, description, etc.). Owner permissions unchanged.
- `fetchPublicOpenRoles` (`PublicShows/api.ts`) and `PublicShows.tsx` now exclude `admin_hidden` productions, same treatment as the existing status/role checks.
- `isProductionLive` (from #326) updated to match, so the "live to the public" indicator stays accurate once something's hidden.
- New `Admin/Companies/api.ts`: `getProductionsForAccount`, `setProductionAdminHidden`.
- `CompanyDetailsModal` now lists a company's shows with status + live/hidden state + a toggle button (gated on the existing `companies` edit permission), logged via a new `production_visibility_change` admin action type.

## Test plan
- [x] 2 new unit tests for `isProductionLive` (admin_hidden true/false).
- [x] 6 new rules tests: admin can toggle only `admin_hidden`; admin cannot change any other field; admin cannot bundle `admin_hidden` with another field in one write; non-admin cannot toggle; owner can still update normally (regression) — plus 1 test confirming the new `admin_actions` enum values are accepted.
- [x] `npm run test` — all passing except the one pre-existing, unrelated `EditPersonalDetails.test.tsx` failure.
- [x] `npm run test:rules` — 32/32 passing.
- [x] `npm run lint` — clean.
- [x] `npm run build` — verified on the pinned Node version (18.13.0 per `.nvmrc`), against the actual committed HEAD.

Deploying to staging for a visual check before merge to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)