### PR TITLE
Fix admin visibility toggle using stale production_id field instead of real doc ID

### DIFF
--- a/src/components/Admin/Companies/api.test.ts
+++ b/src/components/Admin/Companies/api.test.ts
@@ -1,0 +1,107 @@
+import { doc, getDocs, updateDoc } from 'firebase/firestore';
+import { getProductionsForAccount, setProductionAdminHidden } from './api';
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn((_store: unknown, name: string) => ({ id: name })),
+  doc: vi.fn((_store: unknown, _col: string, id: string) => ({ id })),
+  getDocs: vi.fn(),
+  query: vi.fn((ref: unknown, ...clauses: unknown[]) => ({ ref, clauses })),
+  updateDoc: vi.fn(),
+  where: vi.fn((field: string, op: string, value: unknown) => ({
+    field,
+    op,
+    value
+  }))
+}));
+
+const mockGetDocs = vi.mocked(getDocs);
+const mockDoc = vi.mocked(doc);
+const mockUpdateDoc = vi.mocked(updateDoc);
+
+describe('getProductionsForAccount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns [] immediately when accountId is empty, without querying', async () => {
+    const result = await getProductionsForAccount({} as never, '');
+    expect(result).toEqual([]);
+    expect(mockGetDocs).not.toHaveBeenCalled();
+  });
+
+  it('uses the real Firestore document ID, not the production_id field, when they differ', async () => {
+    // Regression: found live in dev where 32 of 59 productions under one
+    // account had a production_id field pointing at a document that
+    // doesn't exist -- using the field as the write target for the admin
+    // visibility toggle silently failed with a permission error instead
+    // of "not found".
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [
+        {
+          id: 'real-doc-id-abc',
+          data: () => ({
+            production_id: 'stale-fake-id-that-does-not-exist',
+            production_name: 'Test Show'
+          })
+        }
+      ]
+    } as never);
+
+    const result = await getProductionsForAccount({} as never, 'acct-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].production_id).toBe('real-doc-id-abc');
+  });
+
+  it('uses the real Firestore document ID even when the production_id field is an empty string', async () => {
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [
+        {
+          id: 'real-doc-id-xyz',
+          data: () => ({
+            production_id: '',
+            production_name: 'Another Show'
+          })
+        }
+      ]
+    } as never);
+
+    const result = await getProductionsForAccount({} as never, 'acct-1');
+
+    expect(result[0].production_id).toBe('real-doc-id-xyz');
+  });
+
+  it('uses the real Firestore document ID even when it happens to match the field (regression, no-op case)', async () => {
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [
+        {
+          id: 'matching-id',
+          data: () => ({
+            production_id: 'matching-id',
+            production_name: 'Clean Show'
+          })
+        }
+      ]
+    } as never);
+
+    const result = await getProductionsForAccount({} as never, 'acct-1');
+
+    expect(result[0].production_id).toBe('matching-id');
+  });
+});
+
+describe('setProductionAdminHidden', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('builds the doc reference from the exact ID passed in', async () => {
+    await setProductionAdminHidden({} as never, 'real-doc-id-abc', true);
+
+    expect(mockDoc).toHaveBeenCalledWith({}, 'productions', 'real-doc-id-abc');
+    expect(mockUpdateDoc).toHaveBeenCalledWith(
+      { id: 'real-doc-id-abc' },
+      { admin_hidden: true }
+    );
+  });
+});

--- a/src/components/Admin/Companies/api.ts
+++ b/src/components/Admin/Companies/api.ts
@@ -36,9 +36,17 @@ export const getProductionsForAccount = async (
 
   return snapshot.docs.map((productionDoc) => {
     const data = productionDoc.data() as Production;
+    // Always use the real Firestore document ID, never the production_id
+    // *field*. Found live in dev: 32 of 59 productions under one account
+    // have a production_id field that's stale/wrong (some empty, some
+    // duplicated across many unrelated docs, none pointing to any real
+    // document) -- using it as a write target silently hit updateDoc() on
+    // a nonexistent document, which Firestore's rules evaluate against a
+    // null resource and report back as "Missing or insufficient
+    // permissions" rather than "not found".
     return {
       ...data,
-      production_id: data.production_id || productionDoc.id
+      production_id: productionDoc.id
     };
   });
 };


### PR DESCRIPTION
## Summary
Root cause of the "Missing or insufficient permissions" errors reported live on staging (account \`yCgisDUo8ykJz1J5Wd9A\`, 59 productions).

\`getProductionsForAccount\` used \`data.production_id || productionDoc.id\`, trusting the \`production_id\` **field** whenever truthy. Checked the actual data directly against Firestore: **32 of 59 productions under that account have a stale \`production_id\` field** — some empty strings, some the exact same fake ID duplicated across 9+ unrelated documents, none of which correspond to any real document in the collection (verified: neither \`5878afd7-...\` nor \`caddfcdf-...\` exist as document IDs).

Using that field as the write target for \`setProductionAdminHidden\` meant \`updateDoc()\` was called against a nonexistent document reference. Firestore's security rules evaluate \`resource.data\` against a \`null\` resource in that case, which surfaces to the client as "permission denied" rather than "not found" — this is fully **deterministic per-document**, not transient as I incorrectly guessed earlier. Some toggles worked because that document's field happened to match its real ID; others didn't.

## Fix
Always use the real Firestore document ID (\`productionDoc.id\`). The \`production_id\` field is not reliable and must not be used as a write-target identifier.

## Test plan
- [x] 5 new unit tests: field mismatch → uses real ID, empty-string field → uses real ID, field matches real ID (no-op regression case), and confirms \`setProductionAdminHidden\` builds the doc reference from exactly the ID it's given.
- [x] \`npm run test\` — 201/203 passing (only the pre-existing unrelated failure).
- [x] \`npm run lint\` — clean.
- [x] \`npm run build\` — verified on pinned Node (18.13.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)