### PR TITLE
Point /roles How it Works link to FAQ page

### DIFF
--- a/src/components/PublicShows/PublicRolesSignUpCTA.tsx
+++ b/src/components/PublicShows/PublicRolesSignUpCTA.tsx
@@ -70,7 +70,7 @@ const PublicRolesSignUpCTA: React.FC<PublicRolesSignUpCTAProps> = ({
               ? 'inline-flex items-center justify-center rounded-full border border-white/70 px-6 py-2 font-montserrat text-sm font-bold uppercase tracking-wider text-white hover:border-white hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-cornflower'
               : 'inline-flex items-center justify-center rounded-full border border-cornflower px-5 py-2 font-montserrat text-sm font-bold uppercase tracking-wider text-cornflower hover:bg-cornflower hover:text-white focus:outline-none focus:ring-2 focus:ring-cornflower focus:ring-offset-2'
           }
-          to="/get-involved"
+          to="/faq"
         >
           How it Works
         </Link>

--- a/src/test/PublicRoles.test.tsx
+++ b/src/test/PublicRoles.test.tsx
@@ -169,7 +169,7 @@ describe('PublicRoles route', () => {
     ).toBeInTheDocument();
   });
 
-  it('top sign-up CTA links to /sign-up and /get-involved when roles exist', async () => {
+  it('top sign-up CTA links to /sign-up and /faq when roles exist', async () => {
     mockFetch.mockResolvedValueOnce(sampleRoles as never);
 
     renderRoute();
@@ -189,7 +189,7 @@ describe('PublicRoles route', () => {
     const howItWorksLinks = screen.getAllByRole('link', {
       name: /learn how chicago artist guide works/i
     });
-    expect(howItWorksLinks[0]).toHaveAttribute('href', '/get-involved');
+    expect(howItWorksLinks[0]).toHaveAttribute('href', '/faq');
   });
 
   it('filters by role type from the drawer', async () => {

--- a/src/test/PublicRolesSignUpCTA.test.tsx
+++ b/src/test/PublicRolesSignUpCTA.test.tsx
@@ -26,12 +26,12 @@ describe('PublicRolesSignUpCTA', () => {
     expect(primaryLink).toHaveAttribute('href', '/sign-up');
   });
 
-  it('secondary action href points to /get-involved', () => {
+  it('secondary action href points to /faq', () => {
     renderCTA();
     const secondaryLink = screen.getByRole('link', {
       name: /learn how chicago artist guide works/i
     });
-    expect(secondaryLink).toHaveAttribute('href', '/get-involved');
+    expect(secondaryLink).toHaveAttribute('href', '/faq');
   });
 
   it('renders default heading and body copy', () => {


### PR DESCRIPTION
## Summary
- Michelle tested `/roles` and flagged (via Anna) that the "How it Works" CTA link should go to the FAQ page (https://www.chicagoartistguide.org/faq), not `/get-involved`.
- `/faq` already exists as an internal route (`src/routes/app-routes.tsx`), so this is just repointing the shared `PublicRolesSignUpCTA` component's secondary link — updates both places it's used (`/roles` top banner + bottom inline CTA, and the empty-state variant).

## Test plan
- [x] Updated the two tests asserting the old `/get-involved` href to expect `/faq`
- [x] `npm run test` — all passing (pre-existing unrelated failures only in stale `.claude/worktrees/*` copies, not this branch)
- [x] `npm run build` succeeds on pinned Node 18.13.0