### PR TITLE
Fix Amplify build account type narrowing

### DIFF
--- a/src/components/Matches/CompanyMatchCard.tsx
+++ b/src/components/Matches/CompanyMatchCard.tsx
@@ -120,7 +120,8 @@ export const CompanyMatchCard = ({
 
   const sendApplyNotifications = async (
     theaterAccountId: string,
-    talentAccountId: string
+    talentAccountId: string,
+    theaterProfile: Profile
   ) => {
     const contactEmail = currentUser?.email || NO_EMAIL;
     const talentFullName = `${account?.data.first_name} ${account?.data.last_name}`;
@@ -142,15 +143,15 @@ export const CompanyMatchCard = ({
       contactEmail
     );
 
-    let toEmail = theater?.primary_contact_email;
+    let toEmail = theaterProfile.primary_contact_email;
 
     if (!toEmail) {
       const theaterAccount = await getTheaterAccountByAccountId(
         firebaseFirestore,
-        theater.account_id
+        theaterProfile.account_id
       );
 
-      if (theaterAccount?.email) {
+      if (theaterAccount && theaterAccount.email) {
         toEmail = theaterAccount.email;
       }
     }
@@ -212,7 +213,8 @@ export const CompanyMatchCard = ({
 
         const messageThreadId = await sendApplyNotifications(
           theaterAccountId,
-          talentAccountId
+          talentAccountId,
+          theater
         );
 
         return messageThreadId;

--- a/src/components/Matches/TalentMatchCard.tsx
+++ b/src/components/Matches/TalentMatchCard.tsx
@@ -90,7 +90,7 @@ export const TalentMatchCard = ({
       shortMessage,
       productionId,
       roleId,
-      email: talentAccount?.email
+      email: talentAccount && talentAccount.email
         ? {
             to: talentAccount.email,
             subject: theaterToArtistEmailSubject(roleName, productionName),

--- a/src/components/Matches/declineNotifications.ts
+++ b/src/components/Matches/declineNotifications.ts
@@ -44,7 +44,7 @@ const notifyDeclinedMatches = async (
       const shortMessage = theaterDeclineArtistMessage(roleName, theaterName);
       const emailText = theaterDeclineArtistEmailText(theaterName, roleName);
 
-      if (account?.email) {
+      if (account && account.email) {
         await sendMessageThreadWithEmail({
           firebaseStore,
           theaterAccountId,

--- a/src/components/Messages/MessageThread.tsx
+++ b/src/components/Messages/MessageThread.tsx
@@ -166,7 +166,7 @@ export const MessageThread: React.FC<
         talentId
       );
 
-      if (!talentAccount?.email) {
+      if (!talentAccount || !talentAccount.email) {
         console.error(
           'Could not find account or account email address for talent.'
         );
@@ -194,7 +194,7 @@ export const MessageThread: React.FC<
         theaterId
       );
 
-      if (theaterAccount?.email) {
+      if (theaterAccount && theaterAccount.email) {
         toEmail = theaterAccount.email;
       } else {
         console.log(


### PR DESCRIPTION
## Summary
- narrow account lookup results before reading email fields
- pass the validated theater profile into the notification helper
- restore the TypeScript production build broken by 899f5a7

## Verification
- npm run build
- affected messaging and decline-notification tests (84/84 passed)
- git diff --check